### PR TITLE
Add runtime config

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+
+interface AppConfig {
+    apiServerGqlUrl: string;
+}
+
+@Injectable({
+    providedIn: "root",
+})
+export class AppConfigService {
+    private appConfig: AppConfig;
+
+    constructor(private http: HttpClient) {}
+
+    loadAppConfig() {
+        return this.http
+            .get("/assets/runtime-config.json")
+            .toPromise()
+            .then((data) => {
+                this.appConfig = data as AppConfig;
+            });
+    }
+
+    get apiServerGqlUrl() {
+        if (!this.appConfig) {
+            throw Error("Config file not loaded!");
+        }
+
+        return this.appConfig.apiServerGqlUrl;
+    }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from "@angular/core";
+import { APP_INITIALIZER, NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
 
 import { AppRoutingModule } from "./app-routing.module";
@@ -45,8 +45,19 @@ import { SecurityContext } from "@angular/core";
 import { NotificationIndicatorComponent } from "./components/notification-indicator/notification-indicator.component";
 import { MonacoEditorModule } from "ngx-monaco-editor";
 import { TimelineComponent } from "./components/timeline-component/timeline.component";
+import { AppConfigService } from "./app-config.service";
 
 const Services = [
+    {
+        provide: APP_INITIALIZER,
+        multi: true,
+        deps: [AppConfigService],
+        useFactory: (appConfigService: AppConfigService) => {
+            return () => {
+                return appConfigService.loadAppConfig();
+            };
+        },
+    },
     Apollo,
     AuthApi,
     SearchApi,
@@ -56,15 +67,15 @@ const Services = [
     SideNavService,
     {
         provide: APOLLO_OPTIONS,
-        useFactory: (httpLink: HttpLink) => {
+        useFactory: (httpLink: HttpLink, appConfig: AppConfigService) => {
             return {
                 cache: new InMemoryCache(),
                 link: httpLink.create({
-                    uri: "http://localhost:8080/graphql",
+                    uri: appConfig.apiServerGqlUrl,
                 }),
             };
         },
-        deps: [HttpLink],
+        deps: [HttpLink, AppConfigService],
     },
 ];
 const MatModules = [

--- a/src/assets/runtime-config.json
+++ b/src/assets/runtime-config.json
@@ -1,0 +1,3 @@
+{
+    "apiServerGqlUrl": "http://localhost:8080/graphql"
+}


### PR DESCRIPTION
Allows us to dynamically configure the application by overriding `assets/runtime-config.json` on the web server.