### PR TITLE
Simpler GraphQL update procedure directly from kamu-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -651,17 +651,6 @@
         "zen-observable": "^0.8.14"
       }
     },
-    "@apollo/rover": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.4.1.tgz",
-      "integrity": "sha512-Dq/GIrODDWz4QCv3sgfTpA0Mw/uPBR+1kZAup/qfXRdDq4IJJHokZRGjdwAZiO4IHENtPbQraQm10xNDY0HkPQ==",
-      "dev": true,
-      "requires": {
-        "binary-install": "^0.1.1",
-        "console.table": "^0.10.0",
-        "detect-libc": "^1.0.3"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -4050,15 +4039,6 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -4262,64 +4242,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "binary-install": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
-      "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.21.1",
-        "rimraf": "^3.0.2",
-        "tar": "^6.1.0"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        }
-      }
     },
     "bindings": {
       "version": "1.5.0",
@@ -5372,15 +5294,6 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
-    "console.table": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
-      "integrity": "sha1-CRcCVYiHW+/XDPLv9L7yxuLXXQQ=",
-      "dev": true,
-      "requires": {
-        "easy-table": "1.1.0"
-      }
-    },
     "constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -6425,12 +6338,6 @@
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
-    },
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -6619,15 +6526,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      }
-    },
-    "easy-table": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
-      "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
-      "dev": true,
-      "requires": {
-        "wcwidth": ">=1.0.1"
       }
     },
     "ecc-jsbn": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "e2e": "ng e2e",
     "prettier": "prettier --write '**/*.{ts,js,html,spec.ts}'",
     "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
-    "gql-update-schema": "npx rover graph introspect http://localhost:8080/graphql > resources/schema.graphql",
-    "gql-codegen": "graphql-codegen --config gql-codegen.yml && prettier --write src/app/api/kamu.graphql.interface.ts"
+    "gql-update-schema": "curl https://raw.githubusercontent.com/kamu-data/kamu-cli/master/resources/schema.gql > resources/schema.graphql",
+    "gql-codegen": "graphql-codegen --config gql-codegen.yml && prettier --write src/app/api/kamu.graphql.interface.ts && sed -i 's/import { gql } from \"apollo-angular\"/import { gql } from \"@apollo\\/client\\/core\"/g' src/app/api/kamu.graphql.interface.ts"
   },
   "private": true,
   "dependencies": {
@@ -53,7 +53,6 @@
     "@angular/cli": "~9.0.0-rc.0",
     "@angular/compiler-cli": "~9.0.0-rc.0",
     "@angular/language-service": "~9.0.0-rc.0",
-    "@apollo/rover": "^0.4.1",
     "@graphql-codegen/add": "^3.1.0",
     "@graphql-codegen/cli": "^2.3.0",
     "@graphql-codegen/typescript-apollo-angular": "^3.3.1",

--- a/resources/schema.graphql
+++ b/resources/schema.graphql
@@ -1,449 +1,645 @@
-schema {
-  query: Query
-  mutation: Mutation
-}
 type AccessToken {
-  accessToken: String!
-  scope: String!
-  tokenType: String!
+	accessToken: String!
+	scope: String!
+	tokenType: String!
 }
+
 interface Account {
-  id: AccountID!
-  name: String!
+	id: AccountID!
+	name: String!
 }
+
 scalar AccountID
+
 type AccountInfo {
-  login: String!
-  name: String!
-  email: String
-  avatarUrl: String
-  gravatarId: String
+	login: String!
+	name: String!
+	email: String
+	avatarUrl: String
+	gravatarId: String
 }
+
 scalar AccountName
+
 type Accounts {
-  "Returns account by its ID"
-  byId(accountId: AccountID!): Account
-  "Returns account by its name"
-  byName(name: String!): Account
+	"""
+	Returns account by its ID
+	"""
+	byId(accountId: AccountID!): Account
+	"""
+	Returns account by its name
+	"""
+	byName(name: String!): Account
 }
+
 type AddData {
-  inputCheckpoint: Multihash
-  outputData: DataSlice!
-  outputCheckpoint: Checkpoint
-  outputWatermark: DateTime
+	inputCheckpoint: Multihash
+	outputData: DataSlice!
+	outputCheckpoint: Checkpoint
+	outputWatermark: DateTime
 }
+
 type AttachmentEmbedded {
-  path: String!
-  content: String!
+	path: String!
+	content: String!
 }
+
 union Attachments = AttachmentsEmbedded
+
 type AttachmentsEmbedded {
-  items: [AttachmentEmbedded!]!
+	items: [AttachmentEmbedded!]!
 }
+
 type Auth {
-  githubLogin(code: String!): LoginResponse!
-  accountInfo(accessToken: String!): AccountInfo!
+	githubLogin(code: String!): LoginResponse!
+	accountInfo(accessToken: String!): AccountInfo!
 }
+
 type BlockInterval {
-  start: Multihash!
-  end: Multihash!
+	start: Multihash!
+	end: Multihash!
 }
+
 type BlockRef {
-  name: String!
-  blockHash: Multihash!
+	name: String!
+	blockHash: Multihash!
 }
+
+
 type Checkpoint {
-  physicalHash: Multihash!
-  size: Int!
+	physicalHash: Multihash!
+	size: Int!
 }
+
 enum CompressionFormat {
-  GZIP
-  ZIP
+	GZIP
+	ZIP
 }
+
 type DataBatch {
-  format: DataBatchFormat!
-  content: String!
-  numRecords: Int!
+	format: DataBatchFormat!
+	content: String!
+	numRecords: Int!
 }
+
 enum DataBatchFormat {
-  JSON
-  JSON_LD
-  JSON_SOA
-  CSV
+	JSON
+	JSON_LD
+	JSON_SOA
+	CSV
 }
+
 type DataQueries {
-  "Executes a specified query and returns its result"
-  query(query: String!, queryDialect: QueryDialect!, dataFormat: DataBatchFormat, schemaFormat: DataSchemaFormat, limit: Int): DataQueryResult!
+	"""
+	Executes a specified query and returns its result
+	"""
+	query(query: String!, queryDialect: QueryDialect!, dataFormat: DataBatchFormat, schemaFormat: DataSchemaFormat, limit: Int): DataQueryResult!
 }
+
 type DataQueryResult {
-  schema: DataSchema!
-  data: DataBatch!
-  limit: Int!
+	schema: DataSchema!
+	data: DataBatch!
+	limit: Int!
 }
+
 type DataSchema {
-  format: DataSchemaFormat!
-  content: String!
+	format: DataSchemaFormat!
+	content: String!
 }
+
 enum DataSchemaFormat {
-  PARQUET
-  PARQUET_JSON
+	PARQUET
+	PARQUET_JSON
 }
+
 type DataSlice {
-  logicalHash: Multihash!
-  physicalHash: Multihash!
-  interval: OffsetInterval!
-  size: Int!
+	logicalHash: Multihash!
+	physicalHash: Multihash!
+	interval: OffsetInterval!
+	size: Int!
 }
+
 type Dataset {
-  "Unique identifier of the dataset"
-  id: DatasetID!
-  """
-  Symbolic name of the dataset.
-  Name can change over the dataset's lifetime. For unique identifier use `id()`.
-  """
-  name: DatasetName!
-  "Returns the user or organization that owns this dataset"
-  owner: Account!
-  "Returns the kind of a dataset (Root or Derivative)"
-  kind: DatasetKind!
-  "Access to the data of the dataset"
-  data: DatasetData!
-  "Access to the metadata of the dataset"
-  metadata: DatasetMetadata!
-  "Creation time of the first metadata block in the chain"
-  createdAt: DateTime!
-  "Creation time of the most recent metadata block in the chain"
-  lastUpdatedAt: DateTime!
+	"""
+	Unique identifier of the dataset
+	"""
+	id: DatasetID!
+	"""
+	Symbolic name of the dataset.
+	Name can change over the dataset's lifetime. For unique identifier use `id()`.
+	"""
+	name: DatasetName!
+	"""
+	Returns the user or organization that owns this dataset
+	"""
+	owner: Account!
+	"""
+	Returns the kind of a dataset (Root or Derivative)
+	"""
+	kind: DatasetKind!
+	"""
+	Access to the data of the dataset
+	"""
+	data: DatasetData!
+	"""
+	Access to the metadata of the dataset
+	"""
+	metadata: DatasetMetadata!
+	"""
+	Creation time of the first metadata block in the chain
+	"""
+	createdAt: DateTime!
+	"""
+	Creation time of the most recent metadata block in the chain
+	"""
+	lastUpdatedAt: DateTime!
 }
+
 type DatasetConnection {
-  "A shorthand for `edges { node { ... } }`"
-  nodes: [Dataset!]!
-  "Approximate number of total nodes"
-  totalCount: Int
-  "Page information"
-  pageInfo: PageBasedInfo!
-  edges: [DatasetEdge!]!
+	"""
+	A shorthand for `edges { node { ... } }`
+	"""
+	nodes: [Dataset!]!
+	"""
+	Approximate number of total nodes
+	"""
+	totalCount: Int
+	"""
+	Page information
+	"""
+	pageInfo: PageBasedInfo!
+	edges: [DatasetEdge!]!
 }
+
 type DatasetData {
-  "Total number of records in this dataset"
-  numRecordsTotal: Int!
-  "An estimated size of data on disk not accounting for replication or caching"
-  estimatedSize: Int!
-  """
-  Returns the specified number of the latest records in the dataset
-  This is equivalent to the SQL query: `SELECT * FROM dataset ORDER BY event_time DESC LIMIT N`
-  """
-  tail(limit: Int, dataFormat: DataBatchFormat, schemaFormat: DataSchemaFormat): DataQueryResult!
+	"""
+	Total number of records in this dataset
+	"""
+	numRecordsTotal: Int!
+	"""
+	An estimated size of data on disk not accounting for replication or caching
+	"""
+	estimatedSize: Int!
+	"""
+	Returns the specified number of the latest records in the dataset
+	This is equivalent to the SQL query: `SELECT * FROM dataset ORDER BY event_time DESC LIMIT N`
+	"""
+	tail(limit: Int, dataFormat: DataBatchFormat, schemaFormat: DataSchemaFormat): DataQueryResult!
 }
+
 type DatasetEdge {
-  node: Dataset!
+	node: Dataset!
 }
+
 scalar DatasetID
+
 enum DatasetKind {
-  ROOT
-  DERIVATIVE
+	ROOT
+	DERIVATIVE
 }
+
 type DatasetMetadata {
-  "Access to the temporal metadata chain of the dataset"
-  chain: MetadataChain!
-  "Last recorded watermark"
-  currentWatermark: DateTime
-  "Latest data schema"
-  currentSchema(format: DataSchemaFormat): DataSchema!
-  "Current upstream dependencies of a dataset"
-  currentUpstreamDependencies: [Dataset!]!
-  "Current downstream dependencies of a dataset"
-  currentDownstreamDependencies: [Dataset!]!
-  "Current source used by the root dataset"
-  currentSource: SetPollingSource
-  "Current transformation used by the derivative dataset"
-  currentTransform: SetTransform
-  "Current descriptive information about the dataset"
-  currentInfo: SetInfo!
-  "Current readme file as discovered from attachments associated with the dataset"
-  currentReadme: String
-  "Current license associated with the dataset"
-  currentLicense: SetLicense
+	"""
+	Access to the temporal metadata chain of the dataset
+	"""
+	chain: MetadataChain!
+	"""
+	Last recorded watermark
+	"""
+	currentWatermark: DateTime
+	"""
+	Latest data schema
+	"""
+	currentSchema(format: DataSchemaFormat): DataSchema!
+	"""
+	Current upstream dependencies of a dataset
+	"""
+	currentUpstreamDependencies: [Dataset!]!
+	"""
+	Current downstream dependencies of a dataset
+	"""
+	currentDownstreamDependencies: [Dataset!]!
+	"""
+	Current source used by the root dataset
+	"""
+	currentSource: SetPollingSource
+	"""
+	Current transformation used by the derivative dataset
+	"""
+	currentTransform: SetTransform
+	"""
+	Current descriptive information about the dataset
+	"""
+	currentInfo: SetInfo!
+	"""
+	Current readme file as discovered from attachments associated with the dataset
+	"""
+	currentReadme: String
+	"""
+	Current license associated with the dataset
+	"""
+	currentLicense: SetLicense
 }
+
 scalar DatasetName
+
 type Datasets {
-  "Returns dataset by its ID"
-  byId(datasetId: DatasetID!): Dataset
-  "Returns dataset by its owner and name"
-  byOwnerAndName(accountName: AccountName!, datasetName: DatasetName!): Dataset
-  "Returns datasets belonging to the specified account"
-  byAccountId(accountId: AccountID!, page: Int, perPage: Int): DatasetConnection!
-  "Returns datasets belonging to the specified account"
-  byAccountName(accountName: AccountName!, page: Int, perPage: Int): DatasetConnection!
+	"""
+	Returns dataset by its ID
+	"""
+	byId(datasetId: DatasetID!): Dataset
+	"""
+	Returns dataset by its owner and name
+	"""
+	byOwnerAndName(accountName: AccountName!, datasetName: DatasetName!): Dataset
+	"""
+	Returns datasets belonging to the specified account
+	"""
+	byAccountId(accountId: AccountID!, page: Int, perPage: Int): DatasetConnection!
+	"""
+	Returns datasets belonging to the specified account
+	"""
+	byAccountName(accountName: AccountName!, page: Int, perPage: Int): DatasetConnection!
 }
+
 """
 Implement the DateTime<Utc> scalar
 
 The input/output is a string in RFC3339 format.
 """
 scalar DateTime
+
 type EnvVar {
-  name: String!
-  value: String
+	name: String!
+	value: String
 }
+
 union EventTimeSource = EventTimeSourceFromMetadata | EventTimeSourceFromPath
+
 type EventTimeSourceFromMetadata {
-  dummy: String
+	dummy: String
 }
+
 type EventTimeSourceFromPath {
-  pattern: String!
-  timestampFormat: String
+	pattern: String!
+	timestampFormat: String
 }
+
 type ExecuteQuery {
-  inputSlices: [InputSlice!]!
-  inputCheckpoint: Multihash
-  outputData: DataSlice
-  outputCheckpoint: Checkpoint
-  outputWatermark: DateTime
+	inputSlices: [InputSlice!]!
+	inputCheckpoint: Multihash
+	outputData: DataSlice
+	outputCheckpoint: Checkpoint
+	outputWatermark: DateTime
 }
+
 union FetchStep = FetchStepUrl | FetchStepFilesGlob | FetchStepContainer
+
 type FetchStepContainer {
-  image: String!
-  command: [String!]
-  args: [String!]
-  env: [EnvVar!]
+	image: String!
+	command: [String!]
+	args: [String!]
+	env: [EnvVar!]
 }
+
 type FetchStepFilesGlob {
-  path: String!
-  eventTime: EventTimeSource
-  cache: SourceCaching
-  order: SourceOrdering
+	path: String!
+	eventTime: EventTimeSource
+	cache: SourceCaching
+	order: SourceOrdering
 }
+
 type FetchStepUrl {
-  url: String!
-  eventTime: EventTimeSource
-  cache: SourceCaching
+	url: String!
+	eventTime: EventTimeSource
+	cache: SourceCaching
 }
-"The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point)."
-scalar Float
+
+
+
 type InputSlice {
-  datasetId: DatasetID!
-  blockInterval: BlockInterval
-  dataInterval: OffsetInterval
+	datasetId: DatasetID!
+	blockInterval: BlockInterval
+	dataInterval: OffsetInterval
 }
+
+
 type LoginResponse {
-  token: AccessToken!
-  accountInfo: AccountInfo!
+	token: AccessToken!
+	accountInfo: AccountInfo!
 }
+
 union MergeStrategy = MergeStrategyAppend | MergeStrategyLedger | MergeStrategySnapshot
+
 type MergeStrategyAppend {
-  dummy: String
+	dummy: String
 }
+
 type MergeStrategyLedger {
-  primaryKey: [String!]!
+	primaryKey: [String!]!
 }
+
 type MergeStrategySnapshot {
-  primaryKey: [String!]!
-  compareColumns: [String!]
-  observationColumn: String
-  obsvAdded: String
-  obsvChanged: String
-  obsvRemoved: String
+	primaryKey: [String!]!
+	compareColumns: [String!]
+	observationColumn: String
+	obsvAdded: String
+	obsvChanged: String
+	obsvRemoved: String
 }
+
 type MetadataBlockConnection {
-  "A shorthand for `edges { node { ... } }`"
-  nodes: [MetadataBlockExtended!]!
-  "Approximate number of total nodes"
-  totalCount: Int
-  "Page information"
-  pageInfo: PageBasedInfo!
-  edges: [MetadataBlockEdge!]!
+	"""
+	A shorthand for `edges { node { ... } }`
+	"""
+	nodes: [MetadataBlockExtended!]!
+	"""
+	Approximate number of total nodes
+	"""
+	totalCount: Int
+	"""
+	Page information
+	"""
+	pageInfo: PageBasedInfo!
+	edges: [MetadataBlockEdge!]!
 }
+
 type MetadataBlockEdge {
-  node: MetadataBlockExtended!
+	node: MetadataBlockExtended!
 }
+
 type MetadataBlockExtended {
-  blockHash: Multihash!
-  prevBlockHash: Multihash
-  systemTime: DateTime!
-  author: Account!
-  event: MetadataEvent!
+	blockHash: Multihash!
+	prevBlockHash: Multihash
+	systemTime: DateTime!
+	author: Account!
+	event: MetadataEvent!
 }
+
 type MetadataChain {
-  "Returns all named metadata block references"
-  refs: [BlockRef!]!
-  "Returns a metadata block corresponding to the specified hash"
-  blockByHash(hash: Multihash!): MetadataBlockExtended
-  "Iterates all metadata blocks in the reverse chronological order"
-  blocks(page: Int, perPage: Int): MetadataBlockConnection!
+	"""
+	Returns all named metadata block references
+	"""
+	refs: [BlockRef!]!
+	"""
+	Returns a metadata block corresponding to the specified hash
+	"""
+	blockByHash(hash: Multihash!): MetadataBlockExtended
+	"""
+	Iterates all metadata blocks in the reverse chronological order
+	"""
+	blocks(page: Int, perPage: Int): MetadataBlockConnection!
 }
+
 union MetadataEvent = AddData | ExecuteQuery | Seed | SetPollingSource | SetTransform | SetVocab | SetWatermark | SetAttachments | SetInfo | SetLicense
+
 scalar Multihash
+
 type Mutation {
-  auth: Auth!
+	auth: Auth!
 }
+
 type OffsetInterval {
-  start: Int!
-  end: Int!
+	start: Int!
+	end: Int!
 }
+
 type Organization implements Account {
-  "Unique and stable identitfier of this organization account"
-  id: AccountID!
-  "Symbolic account name"
-  name: String!
+	"""
+	Unique and stable identitfier of this organization account
+	"""
+	id: AccountID!
+	"""
+	Symbolic account name
+	"""
+	name: String!
 }
+
 type PageBasedInfo {
-  "When paginating backwards, are there more items?"
-  hasPreviousPage: Boolean!
-  "When paginating forwards, are there more items?"
-  hasNextPage: Boolean!
-  "Index of the current page"
-  currentPage: Int!
-  "Approximate number of total pages assuming number of nodes per page stays the same"
-  totalPages: Int
+	"""
+	When paginating backwards, are there more items?
+	"""
+	hasPreviousPage: Boolean!
+	"""
+	When paginating forwards, are there more items?
+	"""
+	hasNextPage: Boolean!
+	"""
+	Index of the current page
+	"""
+	currentPage: Int!
+	"""
+	Approximate number of total pages assuming number of nodes per page stays the same
+	"""
+	totalPages: Int
 }
+
 union PrepStep = PrepStepDecompress | PrepStepPipe
+
 type PrepStepDecompress {
-  format: CompressionFormat!
-  subPath: String
+	format: CompressionFormat!
+	subPath: String
 }
+
 type PrepStepPipe {
-  command: [String!]!
+	command: [String!]!
 }
+
 type Query {
-  "Returns the version of the GQL API"
-  apiVersion: String!
-  "Dataset-related functionality group"
-  datasets: Datasets!
-  "Account-related functionality group"
-  accounts: Accounts!
-  "Search-related functionality group"
-  search: Search!
-  "Querying and data manipulations"
-  data: DataQueries!
+	"""
+	Returns the version of the GQL API
+	"""
+	apiVersion: String!
+	"""
+	Dataset-related functionality group
+	"""
+	datasets: Datasets!
+	"""
+	Account-related functionality group
+	"""
+	accounts: Accounts!
+	"""
+	Search-related functionality group
+	"""
+	search: Search!
+	"""
+	Querying and data manipulations
+	"""
+	data: DataQueries!
 }
+
 enum QueryDialect {
-  DATA_FUSION
+	DATA_FUSION
 }
+
 union ReadStep = ReadStepCsv | ReadStepJsonLines | ReadStepGeoJson | ReadStepEsriShapefile | ReadStepParquet
+
 type ReadStepCsv {
-  schema: [String!]
-  separator: String
-  encoding: String
-  quote: String
-  escape: String
-  comment: String
-  header: Boolean
-  enforceSchema: Boolean
-  inferSchema: Boolean
-  ignoreLeadingWhiteSpace: Boolean
-  ignoreTrailingWhiteSpace: Boolean
-  nullValue: String
-  emptyValue: String
-  nanValue: String
-  positiveInf: String
-  negativeInf: String
-  dateFormat: String
-  timestampFormat: String
-  multiLine: Boolean
+	schema: [String!]
+	separator: String
+	encoding: String
+	quote: String
+	escape: String
+	comment: String
+	header: Boolean
+	enforceSchema: Boolean
+	inferSchema: Boolean
+	ignoreLeadingWhiteSpace: Boolean
+	ignoreTrailingWhiteSpace: Boolean
+	nullValue: String
+	emptyValue: String
+	nanValue: String
+	positiveInf: String
+	negativeInf: String
+	dateFormat: String
+	timestampFormat: String
+	multiLine: Boolean
 }
+
 type ReadStepEsriShapefile {
-  schema: [String!]
-  subPath: String
+	schema: [String!]
+	subPath: String
 }
+
 type ReadStepGeoJson {
-  schema: [String!]
+	schema: [String!]
 }
+
 type ReadStepJsonLines {
-  schema: [String!]
-  dateFormat: String
-  encoding: String
-  multiLine: Boolean
-  primitivesAsString: Boolean
-  timestampFormat: String
+	schema: [String!]
+	dateFormat: String
+	encoding: String
+	multiLine: Boolean
+	primitivesAsString: Boolean
+	timestampFormat: String
 }
+
 type ReadStepParquet {
-  schema: [String!]
+	schema: [String!]
 }
+
 type Search {
-  "Perform search across all resources"
-  query(query: String!, page: Int, perPage: Int): SearchResultConnection!
+	"""
+	Perform search across all resources
+	"""
+	query(query: String!, page: Int, perPage: Int): SearchResultConnection!
 }
+
 union SearchResult = Dataset
+
 type SearchResultConnection {
-  "A shorthand for `edges { node { ... } }`"
-  nodes: [SearchResult!]!
-  "Approximate number of total nodes"
-  totalCount: Int
-  "Page information"
-  pageInfo: PageBasedInfo!
-  edges: [SearchResultEdge!]!
+	"""
+	A shorthand for `edges { node { ... } }`
+	"""
+	nodes: [SearchResult!]!
+	"""
+	Approximate number of total nodes
+	"""
+	totalCount: Int
+	"""
+	Page information
+	"""
+	pageInfo: PageBasedInfo!
+	edges: [SearchResultEdge!]!
 }
+
 type SearchResultEdge {
-  node: SearchResult!
+	node: SearchResult!
 }
+
 type Seed {
-  datasetId: DatasetID!
-  datasetKind: DatasetKind!
+	datasetId: DatasetID!
+	datasetKind: DatasetKind!
 }
+
 type SetAttachments {
-  attachments: Attachments!
+	attachments: Attachments!
 }
+
 type SetInfo {
-  description: String
-  keywords: [String!]
+	description: String
+	keywords: [String!]
 }
+
 type SetLicense {
-  shortName: String!
-  name: String!
-  spdxId: String
-  websiteUrl: String!
+	shortName: String!
+	name: String!
+	spdxId: String
+	websiteUrl: String!
 }
+
 type SetPollingSource {
-  fetch: FetchStep!
-  prepare: [PrepStep!]
-  read: ReadStep!
-  preprocess: Transform
-  merge: MergeStrategy!
+	fetch: FetchStep!
+	prepare: [PrepStep!]
+	read: ReadStep!
+	preprocess: Transform
+	merge: MergeStrategy!
 }
+
 type SetTransform {
-  inputs: [TransformInput!]!
-  transform: Transform!
+	inputs: [TransformInput!]!
+	transform: Transform!
 }
+
 type SetVocab {
-  systemTimeColumn: String
-  eventTimeColumn: String
-  offsetColumn: String
+	systemTimeColumn: String
+	eventTimeColumn: String
+	offsetColumn: String
 }
+
 type SetWatermark {
-  outputWatermark: DateTime!
+	outputWatermark: DateTime!
 }
+
 union SourceCaching = SourceCachingForever
+
 type SourceCachingForever {
-  dummy: String
+	dummy: String
 }
+
 enum SourceOrdering {
-  BY_EVENT_TIME
-  BY_NAME
+	BY_EVENT_TIME
+	BY_NAME
 }
+
 type SqlQueryStep {
-  alias: String
-  query: String!
+	alias: String
+	query: String!
 }
+
+
 type TemporalTable {
-  name: String!
-  primaryKey: [String!]!
+	name: String!
+	primaryKey: [String!]!
 }
+
 union Transform = TransformSql
+
 type TransformInput {
-  id: DatasetID
-  name: DatasetName!
-  dataset: Dataset!
+	id: DatasetID
+	name: DatasetName!
+	dataset: Dataset!
 }
+
 type TransformSql {
-  engine: String!
-  version: String
-  queries: [SqlQueryStep!]!
-  temporalTables: [TemporalTable!]
+	engine: String!
+	version: String
+	queries: [SqlQueryStep!]!
+	temporalTables: [TemporalTable!]
 }
+
 type User implements Account {
-  "Unique and stable identitfier of this user account"
-  id: AccountID!
-  "Symbolic account name"
-  name: String!
+	"""
+	Unique and stable identitfier of this user account
+	"""
+	id: AccountID!
+	"""
+	Symbolic account name
+	"""
+	name: String!
+}
+
+schema {
+	query: Query
+	mutation: Mutation
 }


### PR DESCRIPTION
Got rid of Rover, downloading definition from `kamu-cli` repository instead.
Implemented automatic adjustment of `import { gql }` generated statement to avoid manual edits.