### PR TITLE
Kamu 99: Eliminate improper type casts in lineage graph component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,7 @@ import { NotificationIndicatorComponent } from "./components/notification-indica
 import { MonacoEditorModule } from "ngx-monaco-editor";
 import { AppConfigService } from "./app-config.service";
 import { NavigationService } from "./services/navigation.service";
-import { AppDatasetSubsService } from "./dataset-view/datasetSubs.service";
+import { AppDatasetSubscriptionsService } from "./dataset-view/dataset.subscriptions.service";
 
 const Services = [
     {
@@ -66,7 +66,7 @@ const Services = [
     AppSearchService,
     AppDatasetService,
     NavigationService,
-    AppDatasetSubsService,
+    AppDatasetSubscriptionsService,
     SideNavService,
     {
         provide: APOLLO_OPTIONS,

--- a/src/app/components/dynamic-table/dynamic-table.interface.ts
+++ b/src/app/components/dynamic-table/dynamic-table.interface.ts
@@ -1,4 +1,4 @@
-import { DataRow } from "src/app/dataset-view/datasetSubs.interface";
+import { DataRow } from "src/app/dataset-view/dataset.subscriptions.interface";
 import { DataSchemaField } from "../../interface/search.interface";
 
 export type TableSourceRowInterface = DataSchemaField | DataRow;

--- a/src/app/dataset-view/additional-components/data-component/data-component.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.ts
@@ -1,11 +1,11 @@
 import {
     DataUpdate,
     DataRow,
-} from "src/app/dataset-view/datasetSubs.interface";
+} from "src/app/dataset-view/dataset.subscriptions.interface";
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { DataViewSchema } from "../../../interface/search.interface";
 import DataTabValues from "./mock.data";
-import { AppDatasetSubsService } from "../../datasetSubs.service";
+import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { BaseComponent } from "src/app/common/base.component";
 import { DatasetBasicsFragment } from "src/app/api/kamu.graphql.interface";
 
@@ -28,7 +28,7 @@ export class DataComponent extends BaseComponent implements OnInit {
     public currentSchema?: DataViewSchema;
     public currentData: DataRow[];
 
-    constructor(private appDatasetSubsService: AppDatasetSubsService) {
+    constructor(private appDatasetSubsService: AppDatasetSubscriptionsService) {
         super();
     }
 

--- a/src/app/dataset-view/additional-components/history-component/history-component.ts
+++ b/src/app/dataset-view/additional-components/history-component/history-component.ts
@@ -4,8 +4,8 @@ import {
     PageBasedInfo,
 } from "src/app/api/kamu.graphql.interface";
 import { BaseComponent } from "src/app/common/base.component";
-import { DatasetHistoryUpdate } from "../../datasetSubs.interface";
-import { AppDatasetSubsService } from "../../datasetSubs.service";
+import { DatasetHistoryUpdate } from "../../dataset.subscriptions.interface";
+import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 
 @Component({
     selector: "app-history",
@@ -22,7 +22,7 @@ export class HistoryComponent extends BaseComponent implements OnInit {
         history: MetadataBlockFragment[];
     };
 
-    constructor(private appDatasetSubsService: AppDatasetSubsService) {
+    constructor(private appDatasetSubsService: AppDatasetSubscriptionsService) {
         super();
     }
 

--- a/src/app/dataset-view/additional-components/lineage-component/lineage-component.ts
+++ b/src/app/dataset-view/additional-components/lineage-component/lineage-component.ts
@@ -1,20 +1,132 @@
-import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { Edge } from "@swimlane/ngx-graph/lib/models/edge.model";
 import { ClusterNode, Node } from "@swimlane/ngx-graph/lib/models/node.model";
+import { DatasetBasicsFragment, DatasetKind } from "src/app/api/kamu.graphql.interface";
+import { BaseComponent } from "src/app/common/base.component";
+import { LineageUpdate } from "../../dataset.subscriptions.interface";
+import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 
 @Component({
     selector: "app-lineage",
     templateUrl: "./lineage-component.html",
 })
-export class LineageComponent {
+export class LineageComponent extends BaseComponent implements OnInit {
     @Input() public lineageGraphView: [number, number];
-    @Input() public isAvailableLineageGraph: boolean;
-    @Input() public lineageGraphLink: Edge[];
-    @Input() public lineageGraphNodes: Node[];
-    @Input() public lineageGraphClusters: ClusterNode[];
     @Output() onClickNodeEmit = new EventEmitter<Node>();
+
+    public lineageGraphLink: Edge[] = [];
+    public lineageGraphNodes: Node[] = [];
+    public lineageGraphClusters: ClusterNode[] = [];
+    public isAvailableLineageGraph = false;
+
+    constructor(
+        private appDatasetSubsService: AppDatasetSubscriptionsService,
+    ) {
+        super();
+    }
 
     public onClickNode(node: Node): void {
         this.onClickNodeEmit.emit(node);
     }
+
+    private initLineageGraphProperty(): void {
+        this.lineageGraphNodes = [];
+        this.lineageGraphLink = [];
+    }
+
+    public ngOnInit(): void {
+        this.initLineageGraphProperty();
+        this.lineageGraphClusters = [
+            {
+                id: DatasetKind.Root + "_cluster",
+                label: DatasetKind.Root,
+                data: { customColor: "#A52A2A59" },
+                position: { x: 10, y: 10 },
+                childNodeIds: [],
+            },
+            {
+                id: DatasetKind.Derivative + "_cluster",
+                label: DatasetKind.Derivative,
+                data: { customColor: "#00800039" },
+                position: { x: 10, y: 10 },
+                childNodeIds: [],
+            },
+        ];
+
+        this.trackSubscriptions(
+            this.appDatasetSubsService.onLineageDataChanges.subscribe(
+                (lineageUpdate: LineageUpdate) => {
+                    this.updateGraph(lineageUpdate);
+                }
+            )
+        );
+    }
+
+    private updateGraph(lineageUpdate: LineageUpdate): void {
+        lineageUpdate.nodes.forEach((dataset: DatasetBasicsFragment) => {
+            this.lineageGraphClusters =
+                this.lineageGraphClusters.map(
+                    (cluster: ClusterNode) => {
+                        if (
+                            typeof cluster.childNodeIds ===
+                            "undefined"
+                        ) {
+                            cluster.childNodeIds = [];
+                        }
+
+                        if (cluster.label === dataset.kind) {
+                            cluster.childNodeIds.push(dataset.id as string);
+                        }
+                        return cluster;
+                    },
+                );
+        });
+
+        const edges = lineageUpdate.edges;
+        const currentDataset = lineageUpdate.origin;
+
+        this.initLineageGraphProperty();
+
+        this.isAvailableLineageGraph = edges.length !== 0;
+
+        const uniqueDatasets: Record<string, DatasetBasicsFragment> = {};
+        edges.forEach((edge: DatasetBasicsFragment[]) =>
+            edge.forEach((dataset: DatasetBasicsFragment) => {
+                uniqueDatasets[dataset.id as string] = dataset;
+            }),
+        );
+
+        for (const [id, dataset] of Object.entries(
+            uniqueDatasets,
+        )) {
+            this.lineageGraphNodes.push({
+                id: this.sanitizeID(id),
+                label: dataset.name as string,
+                data: {
+                    id: dataset.id as string,
+                    name: dataset.name as string,
+                    kind: dataset.kind,
+                    isRoot: dataset.kind === DatasetKind.Root,
+                    isCurrent: dataset.id === currentDataset.id,
+                },
+            });
+        }
+
+        edges.forEach((edge: DatasetBasicsFragment[]) => {
+            const source: string = this.sanitizeID(edge[0].id as string);
+            const target: string = this.sanitizeID(edge[1].id as string);
+
+            this.lineageGraphLink.push({
+                id: `${source}__and__${target}`,
+                source,
+                target,
+            });
+        });        
+    }
+
+    // TODO: Use `String.replaceAll()`
+    private sanitizeID(id: string): string {
+        return id.replace(/:/g, "");
+    }
+
 }

--- a/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
@@ -3,8 +3,8 @@ import { NavigationService } from "src/app/services/navigation.service";
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { DataViewSchema } from "../../../interface/search.interface";
 import AppValues from "../../../common/app.values";
-import { AppDatasetSubsService } from "../../datasetSubs.service";
-import { MetadataSchemaUpdate } from "../../datasetSubs.interface";
+import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
+import { MetadataSchemaUpdate } from "../../dataset.subscriptions.interface";
 import { BaseComponent } from "src/app/common/base.component";
 import {
     DatasetBasicsFragment,
@@ -48,7 +48,7 @@ export class MetadataComponent extends BaseComponent implements OnInit {
     };
 
     constructor(
-        private appDatasetSubsService: AppDatasetSubsService,
+        private appDatasetSubsService: AppDatasetSubscriptionsService,
         private navigationService: NavigationService,
     ) {
         super();

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.ts
@@ -1,7 +1,7 @@
 import {
     DataRow,
     OverviewDataUpdate,
-} from "src/app/dataset-view/datasetSubs.interface";
+} from "src/app/dataset-view/dataset.subscriptions.interface";
 import { DatasetKind } from "./../../../api/kamu.graphql.interface";
 import {
     ChangeDetectionStrategy,
@@ -21,7 +21,7 @@ import {
     DatasetOverviewFragment,
     MetadataBlockFragment,
 } from "../../../api/kamu.graphql.interface";
-import { AppDatasetSubsService } from "../../datasetSubs.service";
+import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 
 @Component({
     selector: "app-overview",
@@ -42,7 +42,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
     };
 
     constructor(
-        private appDatasetSubsService: AppDatasetSubsService,
+        private appDatasetSubsService: AppDatasetSubscriptionsService,
         private navigationService: NavigationService,
     ) {
         super();

--- a/src/app/dataset-view/dataset.component.html
+++ b/src/app/dataset-view/dataset.component.html
@@ -46,10 +46,6 @@
             <ng-template [ngIf]="isDatasetViewTypeLineage">
                 <app-lineage
                     [lineageGraphView]="lineageGraphView"
-                    [isAvailableLineageGraph]="isAvailableLineageGraph"
-                    [lineageGraphClusters]="lineageGraphClusters"
-                    [lineageGraphLink]="lineageGraphLink"
-                    [lineageGraphNodes]="lineageGraphNodes"
                     (onClickNodeEmit)="onClickLineageNode($event)"
                 ></app-lineage>
             </ng-template>

--- a/src/app/dataset-view/dataset.service.ts
+++ b/src/app/dataset-view/dataset.service.ts
@@ -249,8 +249,6 @@ export class AppDatasetService {
 
     // TODO: What is the naming convention here exactly?
     public onSearchLineage(info: DatasetInfo): void {
-        this.resetLineageGraph();
-
         this.searchApi
             .getDatasetLineage(info)
             .subscribe((data: GetDatasetLineageQuery) => {
@@ -363,9 +361,10 @@ export class AppDatasetService {
      }
 
     private updatelineageGraph(lineage: DatasetLineageNode) {
+        this.resetLineageGraph();
         this.updateLineageGraphRecords(lineage);
-        this.lineageEdgesChanged(lineage.basics);
         this.lineageNodesChanged();
+        this.lineageEdgesChanged(lineage.basics);
     }
 
     private updateLineageGraphRecords(

--- a/src/app/dataset-view/dataset.subscriptions.interface.ts
+++ b/src/app/dataset-view/dataset.subscriptions.interface.ts
@@ -1,4 +1,5 @@
 import {
+    DatasetBasicsFragment,
     DatasetDataSizeFragment,
     DatasetMetadataDetailsFragment,
     DatasetOverviewFragment,
@@ -27,6 +28,12 @@ export interface MetadataSchemaUpdate {
 export interface DatasetHistoryUpdate {
     history: MetadataBlockFragment[];
     pageInfo: PageBasedInfo;
+}
+
+export interface LineageUpdate {
+    nodes: DatasetBasicsFragment[];
+    edges: DatasetBasicsFragment[][];
+    origin: DatasetBasicsFragment;
 }
 
 export type DataRow = Record<string, string | number>;

--- a/src/app/dataset-view/dataset.subscriptions.service.ts
+++ b/src/app/dataset-view/dataset.subscriptions.service.ts
@@ -3,11 +3,12 @@ import { Injectable } from "@angular/core";
 import {
     DatasetHistoryUpdate,
     DataUpdate,
+    LineageUpdate,
     MetadataSchemaUpdate,
     OverviewDataUpdate,
-} from "./datasetSubs.interface";
+} from "./dataset.subscriptions.interface";
 @Injectable()
-export class AppDatasetSubsService {
+export class AppDatasetSubscriptionsService {
     private datasetOverviewDataChanges$: Subject<OverviewDataUpdate> =
         new ReplaySubject<OverviewDataUpdate>(1 /*bufferSize*/);
     private datasetDataChanges$: Subject<DataUpdate> =
@@ -16,6 +17,8 @@ export class AppDatasetSubsService {
         new ReplaySubject<DatasetHistoryUpdate>(1 /*bufferSize*/);
     private metadataSchemaChanges$: Subject<MetadataSchemaUpdate> =
         new ReplaySubject<MetadataSchemaUpdate>(1 /*bufferSize*/);
+    private lineageChanges$: Subject<LineageUpdate> = 
+        new ReplaySubject<LineageUpdate>(1 /*bufferSize*/);
 
     public changeDatasetOverviewData(data: OverviewDataUpdate): void {
         this.datasetOverviewDataChanges$.next(data);
@@ -47,5 +50,13 @@ export class AppDatasetSubsService {
 
     public metadataSchemaChanges(schema: MetadataSchemaUpdate): void {
         this.metadataSchemaChanges$.next(schema);
+    }
+
+    public changeLineageData(data: LineageUpdate): void {
+        this.lineageChanges$.next(data);
+    }
+
+    public get onLineageDataChanges(): Observable<LineageUpdate> {
+        return this.lineageChanges$.asObservable();
     }
 }

--- a/src/app/interface/search.interface.ts
+++ b/src/app/interface/search.interface.ts
@@ -1,6 +1,6 @@
 import {
     Dataset,
-    DatasetKind,
+    DatasetBasicsFragment,
     PageBasedInfo,
 } from "../api/kamu.graphql.interface";
 
@@ -9,12 +9,6 @@ export interface SearchOverviewInterface {
     totalCount: number;
     pageInfo: PageBasedInfo;
     currentPage: number;
-}
-
-export interface DatasetKindInterface {
-    id: string;
-    name: string;
-    kind: DatasetKind;
 }
 
 export interface DatasetIDsInterface {
@@ -28,21 +22,10 @@ export enum TypeNames {
     datasetType = "Dataset",
 }
 
-export interface DatasetLineageResponse {
-    __typename: string;
-    id: string;
-    kind: DatasetKind;
-    name: string;
-    metadata: DatasetCurrentUpstreamDependencies;
-}
-
-export interface DatasetCurrentUpstreamDependencies {
-    __typename: string;
-    id: string;
-    kind: DatasetKind;
-    name: string;
-    currentDownstreamDependencies?: DatasetLineageResponse[];
-    currentUpstreamDependencies?: DatasetLineageResponse[];
+export interface DatasetLineageNode {
+    basics: DatasetBasicsFragment;
+    downstreamDependencies: DatasetLineageNode[];
+    upstreamDependencies: DatasetLineageNode[];
 }
 
 export interface DataViewSchema {


### PR DESCRIPTION
- Reworked datastructures used to prepare lineage graph data
- Unified naming of lineage-related items
- Restructured lineage graph update responsibilities in similar manner as other dataset tabs
- Eliminated redundand lineage graph resets
