### PR TITLE
Fixed GitHub secondary authentication errors

### DIFF
--- a/src/app/api/gql/github-login.graphql
+++ b/src/app/api/gql/github-login.graphql
@@ -12,3 +12,11 @@ mutation GithubLogin($code: String!) {
     }
   }
 }
+
+mutation FetchAccountInfo($accessToken: String!) {
+  auth {
+    accountInfo(accessToken: $accessToken) {
+      ...AccountDetails
+    }
+  }
+}

--- a/src/app/api/kamu.graphql.interface.ts
+++ b/src/app/api/kamu.graphql.interface.ts
@@ -1129,6 +1129,18 @@ export type GithubLoginMutation = {
     };
 };
 
+export type FetchAccountInfoMutationVariables = Exact<{
+    accessToken: Scalars["String"];
+}>;
+
+export type FetchAccountInfoMutation = {
+    __typename?: "Mutation";
+    auth: {
+        __typename?: "Auth";
+        accountInfo: { __typename?: "AccountInfo" } & AccountDetailsFragment;
+    };
+};
+
 export type SearchDatasetsAutocompleteQueryVariables = Exact<{
     query: Scalars["String"];
     perPage?: InputMaybe<Scalars["Int"]>;
@@ -1645,6 +1657,30 @@ export class GithubLoginGQL extends Apollo.Mutation<
     GithubLoginMutationVariables
 > {
     document = GithubLoginDocument;
+
+    constructor(apollo: Apollo.Apollo) {
+        super(apollo);
+    }
+}
+export const FetchAccountInfoDocument = gql`
+    mutation FetchAccountInfo($accessToken: String!) {
+        auth {
+            accountInfo(accessToken: $accessToken) {
+                ...AccountDetails
+            }
+        }
+    }
+    ${AccountDetailsFragmentDoc}
+`;
+
+@Injectable({
+    providedIn: "root",
+})
+export class FetchAccountInfoGQL extends Apollo.Mutation<
+    FetchAccountInfoMutation,
+    FetchAccountInfoMutationVariables
+> {
+    document = FetchAccountInfoDocument;
 
     constructor(apollo: Apollo.Apollo) {
         super(apollo);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,19 +71,16 @@ export class AppComponent extends BaseComponent implements OnInit {
     }
 
     authentification(): void {
-        const code: string | null = localStorage.getItem(
-            AppValues.localStorageCode,
-        );
-
+        const accessToken: string | null = localStorage.getItem(AppValues.localStorageAccessToken);
         if (
             location.href.includes(ProjectLinks.urlLogin) ||
             location.href.includes(ProjectLinks.urlGithubCallback)
         ) {
             return;
         } else {
-            if (typeof code === "string" && !this.authApi.isAuthUser) {
+            if (typeof accessToken === "string" && !this.authApi.isAuthUser) {
                 this.trackSubscription(
-                    this.authApi.getUserInfoAndToken(code).subscribe(),
+                    this.authApi.fetchUserInfoFromAccessToken(accessToken).subscribe(),
                 );
                 return;
             }

--- a/src/app/auth/github-callback/github.callback.ts
+++ b/src/app/auth/github-callback/github.callback.ts
@@ -24,7 +24,7 @@ export class GithubCallbackComponent extends BaseComponent implements OnInit {
         this.trackSubscription(
             this.route.queryParams.subscribe((param: Params) => {
                 this.authApi
-                    .getUserInfoAndToken(param.code as string)
+                    .fetchUserInfoAndTokenFromGithubCallackCode(param.code as string)
                     .subscribe(() => this.navigationService.navigateToHome());
             }),
         );

--- a/src/app/common/app.types.ts
+++ b/src/app/common/app.types.ts
@@ -1,1 +1,2 @@
 export type MaybeNull<T> = T | null;
+export type MaybeUndefined<T> = T | undefined;

--- a/src/app/common/app.values.ts
+++ b/src/app/common/app.values.ts
@@ -4,8 +4,7 @@ import * as moment from "moment-timezone";
 @Injectable()
 export default class AppValues {
     public static appLogo = "assets/icons/kamu_logo_icon.svg";
-    public static localStorageCode = "code";
-    public static localStorageAccessToken = "code";
+    public static localStorageAccessToken = "access_token";
     public static defaultUsername = "anonymous";
     public static httpPattern = new RegExp(/^(http:\/\/)|(https:\/\/)/i);
     public static displayDateFormat = "DD MMM YYYY";


### PR DESCRIPTION
- Remembering access token, not a short-lived temporary code from Github authentication callback
- When access token is present in local store, reusing it to extract account information
- Better error handling within authentication API