### PR TITLE
Kamu 141 Safe reaction when dataset has no schema yet

### DIFF
--- a/resources/schema.graphql
+++ b/resources/schema.graphql
@@ -109,7 +109,7 @@ enum DataQueryResultErrorKind {
 }
 
 type DataQueryResultSuccess {
-	schema: DataSchema!
+	schema: DataSchema
 	data: DataBatch!
 	limit: Int!
 }

--- a/resources/schema.graphql
+++ b/resources/schema.graphql
@@ -222,7 +222,7 @@ type DatasetMetadata {
 	"""
 	Latest data schema
 	"""
-	currentSchema(format: DataSchemaFormat): DataSchema!
+	currentSchema(format: DataSchemaFormat): DataSchema
 	"""
 	Current upstream dependencies of a dataset
 	"""

--- a/src/app/api/kamu.graphql.interface.ts
+++ b/src/app/api/kamu.graphql.interface.ts
@@ -173,7 +173,7 @@ export type DataQueryResultSuccess = {
     __typename?: "DataQueryResultSuccess";
     data: DataBatch;
     limit: Scalars["Int"];
-    schema: DataSchema;
+    schema?: Maybe<DataSchema>;
 };
 
 export type DataSchema = {
@@ -1053,11 +1053,11 @@ export type AccountDetailsFragment = {
 
 export type DataQueryResultSuccessViewFragment = {
     __typename?: "DataQueryResultSuccess";
-    schema: {
+    schema?: {
         __typename?: "DataSchema";
         format: DataSchemaFormat;
         content: string;
-    };
+    } | null;
     data: {
         __typename?: "DataBatch";
         format: DataBatchFormat;

--- a/src/app/api/kamu.graphql.interface.ts
+++ b/src/app/api/kamu.graphql.interface.ts
@@ -271,7 +271,7 @@ export type DatasetMetadata = {
     /** Current readme file as discovered from attachments associated with the dataset */
     currentReadme?: Maybe<Scalars["String"]>;
     /** Latest data schema */
-    currentSchema: DataSchema;
+    currentSchema?: Maybe<DataSchema>;
     /** Current source used by the root dataset */
     currentSource?: Maybe<SetPollingSource>;
     /** Current transformation used by the derivative dataset */
@@ -1253,11 +1253,11 @@ export type DatasetMetadataSummaryFragment = {
         currentTransform?:
             | ({ __typename?: "SetTransform" } & DatasetTransformFragment)
             | null;
-        currentSchema: {
+        currentSchema?: {
             __typename: "DataSchema";
             format: DataSchemaFormat;
             content: string;
-        };
+        } | null;
     };
 } & DatasetReadmeFragment &
     DatasetLastUpdateFragment;

--- a/src/app/dataset-view/additional-components/data-component/data-component.html
+++ b/src/app/dataset-view/additional-components/data-component/data-component.html
@@ -1,11 +1,13 @@
 <div class="dataset-view-data-result-container">
     <div class="search-result-container__content">
-        <h2 class="box-title align-items-center pb-3 m-0">Schema:</h2>
-        <app-dynamic-table
-            [hasTableHeader]="true"
-            [schemaFields]="currentSchema ? currentSchema.fields : []"
-            [idTable]="'schema-block-table'"
-        ></app-dynamic-table>
+        <ng-container *ngIf="currentSchema">
+            <h2 class="box-title align-items-center pb-3 m-0">Schema:</h2>
+            <app-dynamic-table
+                [hasTableHeader]="true"
+                [schemaFields]="currentSchema.fields"
+                [idTable]="'schema-block-table'"
+            ></app-dynamic-table>
+        </ng-container>
         <div>
             <h2 class="box-title align-items-center pb-3 pt-3 m-0">
                 Saved Queries

--- a/src/app/dataset-view/additional-components/data-component/data-component.spec.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.spec.ts
@@ -9,7 +9,6 @@ import { emitClickOnElement } from "src/app/common/base-test.helpers.spec";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { mockDataUpdate, mockSqlErrorUpdate } from "../data-tabs.mock";
 import { first } from "rxjs/operators";
-import { DEFAULT_DATASET_SCHEMA } from "src/app/interface/dataset.interface";
 
 describe("DataComponent", () => {
     let component: DataComponent;
@@ -48,12 +47,12 @@ describe("DataComponent", () => {
     it("should check #ngOninit", () => {
         component.datasetBasics = mockDatasetBasicsFragment;
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
+        expect(component.currentSchema).toEqual(null);
         expect(component.sqlErrorMarker).toBe(null);
 
         component.ngOnInit();
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
+        expect(component.currentSchema).toEqual(null);
         expect(component.sqlRequestCode).toEqual(
             `select\n  *\nfrom 'mockName'`,
         );
@@ -73,7 +72,7 @@ describe("DataComponent", () => {
         appDatasetSubsService.observeSqlErrorOccurred(mockSqlErrorUpdate);
 
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
+        expect(component.currentSchema).toEqual(null);
         expect(component.sqlErrorMarker).toBe(mockSqlErrorUpdate.error);        
     });
 });

--- a/src/app/dataset-view/additional-components/data-component/data-component.spec.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.spec.ts
@@ -9,6 +9,7 @@ import { emitClickOnElement } from "src/app/common/base-test.helpers.spec";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { mockDataUpdate, mockSqlErrorUpdate } from "../data-tabs.mock";
 import { first } from "rxjs/operators";
+import { DEFAULT_DATASET_SCHEMA } from "src/app/interface/dataset.interface";
 
 describe("DataComponent", () => {
     let component: DataComponent;
@@ -47,12 +48,12 @@ describe("DataComponent", () => {
     it("should check #ngOninit", () => {
         component.datasetBasics = mockDatasetBasicsFragment;
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DataComponent.DefaultDatasetSchema);
+        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
         expect(component.sqlErrorMarker).toBe(null);
 
         component.ngOnInit();
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DataComponent.DefaultDatasetSchema);
+        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
         expect(component.sqlRequestCode).toEqual(
             `select\n  *\nfrom 'mockName'`,
         );
@@ -72,7 +73,7 @@ describe("DataComponent", () => {
         appDatasetSubsService.observeSqlErrorOccurred(mockSqlErrorUpdate);
 
         expect(component.currentData).toEqual([]);
-        expect(component.currentSchema).toEqual(DataComponent.DefaultDatasetSchema);
+        expect(component.currentSchema).toEqual(DEFAULT_DATASET_SCHEMA);
         expect(component.sqlErrorMarker).toBe(mockSqlErrorUpdate.error);        
     });
 });

--- a/src/app/dataset-view/additional-components/data-component/data-component.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.ts
@@ -11,7 +11,7 @@ import {
     OnInit,
     Output,
 } from "@angular/core";
-import { DataRow, DatasetSchema, DEFAULT_DATASET_SCHEMA } from "../../../interface/dataset.interface";
+import { DataRow, DatasetSchema } from "../../../interface/dataset.interface";
 import DataTabValues from "./mock.data";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { BaseComponent } from "src/app/common/base.component";
@@ -40,7 +40,7 @@ export class DataComponent extends BaseComponent implements OnInit {
     public sqlRequestCode = `select\n  *\nfrom `;
 
     public sqlErrorMarker: MaybeNull<string> = null;
-    public currentSchema: DatasetSchema = DEFAULT_DATASET_SCHEMA;
+    public currentSchema: MaybeNull<DatasetSchema> = null;
     public currentData: DataRow[] = [];
 
     constructor(
@@ -70,7 +70,7 @@ export class DataComponent extends BaseComponent implements OnInit {
             this.appDatasetSubsService.onDatasetDataSqlErrorOccured.subscribe(
                 (dataSqlErrorUpdate: DataSqlErrorUpdate) => {
                     this.currentData = [];
-                    this.currentSchema = DEFAULT_DATASET_SCHEMA;
+                    this.currentSchema = null;
                     this.sqlErrorMarker = dataSqlErrorUpdate.error;
                     this.cdr.markForCheck();
                 },

--- a/src/app/dataset-view/additional-components/data-component/data-component.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.ts
@@ -11,7 +11,7 @@ import {
     OnInit,
     Output,
 } from "@angular/core";
-import { DataRow, DatasetSchema } from "../../../interface/dataset.interface";
+import { DataRow, DatasetSchema, DEFAULT_DATASET_SCHEMA } from "../../../interface/dataset.interface";
 import DataTabValues from "./mock.data";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { BaseComponent } from "src/app/common/base.component";
@@ -25,11 +25,6 @@ import { MaybeNull } from "src/app/common/app.types";
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataComponent extends BaseComponent implements OnInit {
-    public static readonly DefaultDatasetSchema: DatasetSchema = {
-        name: "arrow_schema",
-        type: "struct",
-        fields: [],
-    };
 
     @Input() public datasetBasics?: DatasetBasicsFragment;
     @Output() public runSQLRequestEmit = new EventEmitter<string>();
@@ -45,7 +40,7 @@ export class DataComponent extends BaseComponent implements OnInit {
     public sqlRequestCode = `select\n  *\nfrom `;
 
     public sqlErrorMarker: MaybeNull<string> = null;
-    public currentSchema: DatasetSchema = DataComponent.DefaultDatasetSchema;
+    public currentSchema: DatasetSchema = DEFAULT_DATASET_SCHEMA;
     public currentData: DataRow[] = [];
 
     constructor(
@@ -75,7 +70,7 @@ export class DataComponent extends BaseComponent implements OnInit {
             this.appDatasetSubsService.onDatasetDataSqlErrorOccured.subscribe(
                 (dataSqlErrorUpdate: DataSqlErrorUpdate) => {
                     this.currentData = [];
-                    this.currentSchema = DataComponent.DefaultDatasetSchema;
+                    this.currentSchema = DEFAULT_DATASET_SCHEMA;
                     this.sqlErrorMarker = dataSqlErrorUpdate.error;
                     this.cdr.markForCheck();
                 },

--- a/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
@@ -19,6 +19,7 @@ import {
     PageBasedInfo,
 } from "src/app/api/kamu.graphql.interface";
 import { momentConvertDatetoLocalWithFormat } from "src/app/common/app.helpers";
+import { MaybeNull } from "src/app/common/app.types";
 
 @Component({
     selector: "app-metadata",
@@ -43,7 +44,7 @@ export class MetadataComponent extends BaseComponent implements OnInit {
     };
 
     public currentState?: {
-        schema: DatasetSchema;
+        schema: MaybeNull<DatasetSchema>;
         metadata: DatasetMetadataSummaryFragment;
         pageInfo: PageBasedInfo;
     };

--- a/src/app/dataset-view/additional-components/metadata-component/metadata.component.html
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata.component.html
@@ -13,7 +13,7 @@
 
         <ng-container *ngIf="currentState">
             <div class="d-flex flex-column gap-4 mt-4">
-                <div class="position-relative border border-1 p-2 rounded-3">
+                <div class="position-relative border border-1 p-2 rounded-3" *ngIf="currentState.schema">
                     <span
                         class="position-absolute text-muted group-box-label text-uppercase"
                         >Schema</span
@@ -27,11 +27,7 @@
                         >
                             <app-dynamic-table
                                 [hasTableHeader]="true"
-                                [schemaFields]="
-                                    currentState
-                                        ? currentState.schema.fields
-                                        : []
-                                "
+                                [schemaFields]="currentState.schema.fields"
                                 [idTable]="'schema-block-table'"
                             ></app-dynamic-table>
                         </app-block-row-data>
@@ -39,7 +35,6 @@
                 </div>
                 <div
                     *ngIf="
-                        currentState &&
                         currentState.metadata.metadata.currentLicense
                     "
                     class="position-relative border border-1 p-2 rounded-3"
@@ -112,7 +107,6 @@
 
                 <ng-container
                     *ngIf="
-                        currentState &&
                         currentState.metadata.metadata.currentSource
                     "
                 >

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.html
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.html
@@ -38,8 +38,9 @@
                 [datasetName]="datasetBasics.name"
             ></app-overview-history-summary-header>
             <app-dynamic-table
+                *ngIf="currentState && currentState.schema"
                 [hasTableHeader]="true"
-                [schemaFields]="currentState ? currentState.schema.fields : []"
+                [schemaFields]="currentState.schema.fields"
                 [dataRows]="currentState ? currentState.data : []"
             ></app-dynamic-table>
             <div id="file-readme-dataset-template-md" class="file my-4">

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../api/kamu.graphql.interface";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { DataRow, DatasetSchema } from "src/app/interface/dataset.interface";
+import { MaybeNull } from "src/app/common/app.types";
 
 @Component({
     selector: "app-overview",
@@ -34,7 +35,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
     @Output() selectTopicEmit = new EventEmitter<string>();
 
     public currentState?: {
-        schema: DatasetSchema;
+        schema: MaybeNull<DatasetSchema>;
         data: DataRow[];
         overview: DatasetOverviewFragment;
         size: DatasetDataSizeFragment;

--- a/src/app/dataset-view/dataset.service.ts
+++ b/src/app/dataset-view/dataset.service.ts
@@ -13,6 +13,7 @@ import {
     DataRow,
     DatasetLineageNode,
     DatasetSchema,
+    DEFAULT_DATASET_SCHEMA,
 } from "../interface/dataset.interface";
 import {
     DatasetBasicsFragment,
@@ -34,6 +35,7 @@ import {
 import { DatasetApi } from "../api/dataset.api";
 import { DatasetNotFoundError } from "../common/errors";
 import { catchError, map } from "rxjs/operators";
+
 
 @Injectable({ providedIn: "root" })
 export class DatasetService {
@@ -59,10 +61,10 @@ export class DatasetService {
                 if (data.datasets.byOwnerAndName) {
                     const dataTail = data.datasets.byOwnerAndName.data.tail;
                     if (dataTail.__typename === "DataQueryResultSuccess") {
-                        const schema: DatasetSchema = JSON.parse(
-                            data.datasets.byOwnerAndName.metadata.currentSchema
-                                .content,
-                        ) as DatasetSchema;
+                        const schema: DatasetSchema = 
+                            data.datasets.byOwnerAndName.metadata.currentSchema 
+                                ? JSON.parse(data.datasets.byOwnerAndName.metadata.currentSchema.content) as DatasetSchema 
+                                : DEFAULT_DATASET_SCHEMA;
 
                         this.datasetUpdate(data.datasets.byOwnerAndName);
                         this.overviewTabDataUpdate(

--- a/src/app/dataset-view/dataset.service.ts
+++ b/src/app/dataset-view/dataset.service.ts
@@ -13,7 +13,6 @@ import {
     DataRow,
     DatasetLineageNode,
     DatasetSchema,
-    DEFAULT_DATASET_SCHEMA,
 } from "../interface/dataset.interface";
 import {
     DatasetBasicsFragment,
@@ -35,6 +34,7 @@ import {
 import { DatasetApi } from "../api/dataset.api";
 import { DatasetNotFoundError } from "../common/errors";
 import { catchError, map } from "rxjs/operators";
+import { MaybeNull } from "../common/app.types";
 
 
 @Injectable({ providedIn: "root" })
@@ -61,10 +61,10 @@ export class DatasetService {
                 if (data.datasets.byOwnerAndName) {
                     const dataTail = data.datasets.byOwnerAndName.data.tail;
                     if (dataTail.__typename === "DataQueryResultSuccess") {
-                        const schema: DatasetSchema = 
+                        const schema: MaybeNull<DatasetSchema> = 
                             data.datasets.byOwnerAndName.metadata.currentSchema 
                                 ? JSON.parse(data.datasets.byOwnerAndName.metadata.currentSchema.content) as DatasetSchema 
-                                : DEFAULT_DATASET_SCHEMA;
+                                : null;
 
                         this.datasetUpdate(data.datasets.byOwnerAndName);
                         this.overviewTabDataUpdate(
@@ -134,10 +134,10 @@ export class DatasetService {
                 if (queryResult.__typename === "DataQueryResultSuccess") {
                     const content: DataRow[] =
                         DatasetService.parseDataRows(queryResult);
-                    const schema: DatasetSchema = 
+                    const schema: MaybeNull<DatasetSchema> = 
                         queryResult.schema
                             ? DatasetService.parseSchema(queryResult.schema.content)
-                            : DEFAULT_DATASET_SCHEMA;
+                            : null;
                     const dataUpdate: DataUpdate = { content, schema };
                     this.appDatasetSubsService.changeDatasetData(dataUpdate);
                 } else if (
@@ -168,7 +168,7 @@ export class DatasetService {
     private overviewTabDataUpdate(
         overview: DatasetOverviewFragment,
         size: DatasetDataSizeFragment,
-        schema: DatasetSchema,
+        schema: MaybeNull<DatasetSchema>,
         tail: DataQueryResultSuccessViewFragment,
     ): void {
         const content: DataRow[] = DatasetService.parseDataRows(tail);
@@ -185,7 +185,7 @@ export class DatasetService {
     }
 
     private dataTabDataUpdate(
-        schema: DatasetSchema,
+        schema: MaybeNull<DatasetSchema>,
         tail: DataQueryResultSuccessViewFragment,
     ): void {
         const content: DataRow[] = DatasetService.parseDataRows(tail);
@@ -195,7 +195,7 @@ export class DatasetService {
 
     private metadataTabDataUpdate(
         data: GetDatasetMainDataQuery,
-        schema: DatasetSchema,
+        schema: MaybeNull<DatasetSchema>,
     ): void {
         if (data.datasets.byOwnerAndName) {
             const metadata: DatasetMetadataSummaryFragment =

--- a/src/app/dataset-view/dataset.service.ts
+++ b/src/app/dataset-view/dataset.service.ts
@@ -134,9 +134,10 @@ export class DatasetService {
                 if (queryResult.__typename === "DataQueryResultSuccess") {
                     const content: DataRow[] =
                         DatasetService.parseDataRows(queryResult);
-                    const schema: DatasetSchema = DatasetService.parseSchema(
-                        queryResult.schema.content,
-                    );
+                    const schema: DatasetSchema = 
+                        queryResult.schema
+                            ? DatasetService.parseSchema(queryResult.schema.content)
+                            : DEFAULT_DATASET_SCHEMA;
                     const dataUpdate: DataUpdate = { content, schema };
                     this.appDatasetSubsService.changeDatasetData(dataUpdate);
                 } else if (

--- a/src/app/dataset-view/dataset.subscriptions.interface.ts
+++ b/src/app/dataset-view/dataset.subscriptions.interface.ts
@@ -7,16 +7,17 @@ import {
     MetadataBlockFragment,
 } from "../api/kamu.graphql.interface";
 import { DataRow, DatasetSchema } from "../interface/dataset.interface";
+import { MaybeNull } from "../common/app.types";
 
 export interface OverviewDataUpdate {
-    schema: DatasetSchema;
+    schema: MaybeNull<DatasetSchema>;
     content: DataRow[];
     overview: DatasetOverviewFragment;
     size: DatasetDataSizeFragment;
 }
 
 export interface DataUpdate {
-    schema: DatasetSchema;
+    schema: MaybeNull<DatasetSchema>;
     content: DataRow[];
 }
 
@@ -25,7 +26,7 @@ export interface DataSqlErrorUpdate {
 }
 
 export interface MetadataSchemaUpdate {
-    schema: DatasetSchema;
+    schema: MaybeNull<DatasetSchema>;
     metadata: DatasetMetadataSummaryFragment;
     pageInfo: DatasetPageInfoFragment;
 }

--- a/src/app/interface/dataset.interface.ts
+++ b/src/app/interface/dataset.interface.ts
@@ -18,12 +18,6 @@ export interface DatasetSchema {
     fields: DataSchemaField[];
 }
 
-export const DEFAULT_DATASET_SCHEMA: DatasetSchema = {
-    name: "arrow_schema",
-    type: "struct",
-    fields: [],
-};
-
 export interface DataSchemaField {
     name: string;
     repetition: string;

--- a/src/app/interface/dataset.interface.ts
+++ b/src/app/interface/dataset.interface.ts
@@ -18,6 +18,12 @@ export interface DatasetSchema {
     fields: DataSchemaField[];
 }
 
+export const DEFAULT_DATASET_SCHEMA: DatasetSchema = {
+    name: "arrow_schema",
+    type: "struct",
+    fields: [],
+};
+
 export interface DataSchemaField {
     name: string;
     repetition: string;


### PR DESCRIPTION
- Update of GraphQL schema, following CLI branch (https://github.com/kamu-data/kamu-cli/pull/123/)
- Detecting no schema passed and properly propagating to dataset viewer components
- Hiding schema-related sections, when schema is unavailable