### PR TITLE
`defaultScalarType` option for GraphQL code generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Angular 14.3
 - Switched to different Angular wrapper for Monaco editor (ngx-monaco-editor-v2)
 - Selected library updates/downgrades to align with Angular 14.3 and Node.JS 16.x
+- GraphQL code generator tuned to produce string type by default for scalars
 
 ## [0.8.0] - 2023-08-04
 ### Added

--- a/gql-codegen.yml
+++ b/gql-codegen.yml
@@ -5,9 +5,10 @@ generates:
   src/app/api/kamu.graphql.interface.ts:
     plugins:
       - add:
-          content: '// THIS FILE IS GENERATED, DO NOT EDIT!'
+          content: "// THIS FILE IS GENERATED, DO NOT EDIT!"
       - typescript
       - typescript-operations
       - typescript-apollo-angular
     config:
       inlineFragmentTypes: combine
+      defaultScalarType: string

--- a/src/app/api/dataset.api.spec.ts
+++ b/src/app/api/dataset.api.spec.ts
@@ -28,6 +28,7 @@ import {
     GetMetadataBlockDocument,
     GetMetadataBlockQuery,
 } from "./kamu.graphql.interface";
+import { MaybeNullOrUndefined } from "../common/app.types";
 
 describe("DatasetApi", () => {
     let service: DatasetApi;
@@ -176,7 +177,7 @@ describe("DatasetApi", () => {
                 datasetId: mockDatasetId,
                 event: mockEvent,
             })
-            .subscribe((res: CommitEventToDatasetMutation | null | undefined) => {
+            .subscribe((res: MaybeNullOrUndefined<CommitEventToDatasetMutation>) => {
                 expect(res?.datasets.byId?.metadata.chain.commitEvent.__typename).toEqual("CommitResultSuccess");
             });
 

--- a/src/app/api/dataset.api.ts
+++ b/src/app/api/dataset.api.ts
@@ -39,6 +39,7 @@ import {
     CreateEmptyDatasetGQL,
 } from "./kamu.graphql.interface";
 import { MutationResult } from "apollo-angular";
+import { MaybeNullOrUndefined } from "../common/app.types";
 
 @Injectable({ providedIn: "root" })
 export class DatasetApi {
@@ -192,7 +193,7 @@ export class DatasetApi {
     public createDatasetFromSnapshot(
         accountId: string,
         snapshot: string,
-    ): Observable<CreateDatasetFromSnapshotMutation | undefined | null> {
+    ): Observable<MaybeNullOrUndefined<CreateDatasetFromSnapshotMutation>> {
         return this.createDatasetFromSnapshotGQL.mutate({ accountId, snapshot }).pipe(
             first(),
             map((result: MutationResult<CreateDatasetFromSnapshotMutation>) => {
@@ -205,7 +206,7 @@ export class DatasetApi {
         accountId: string,
         datasetKind: DatasetKind,
         datasetName: string,
-    ): Observable<CreateEmptyDatasetMutation | null | undefined> {
+    ): Observable<MaybeNullOrUndefined<CreateEmptyDatasetMutation>> {
         return this.createEmptyDatasetGQL.mutate({ accountId, datasetKind, datasetName }).pipe(
             first(),
             map((result: MutationResult<CreateEmptyDatasetMutation>) => {
@@ -217,7 +218,7 @@ export class DatasetApi {
     public commitEvent(params: {
         datasetId: string;
         event: string;
-    }): Observable<CommitEventToDatasetMutation | null | undefined> {
+    }): Observable<MaybeNullOrUndefined<CommitEventToDatasetMutation>> {
         return this.commitEventToDatasetGQL
             .mutate({
                 datasetId: params.datasetId,
@@ -231,7 +232,7 @@ export class DatasetApi {
             );
     }
 
-    public updateReadme(datasetId: string, content: string): Observable<UpdateReadmeMutation | null | undefined> {
+    public updateReadme(datasetId: string, content: string): Observable<MaybeNullOrUndefined<UpdateReadmeMutation>> {
         return this.updateReadmeGQL
             .mutate({
                 datasetId,
@@ -245,7 +246,7 @@ export class DatasetApi {
             );
     }
 
-    public deleteDataset(datasetId: string): Observable<DeleteDatasetMutation | null | undefined> {
+    public deleteDataset(datasetId: string): Observable<MaybeNullOrUndefined<DeleteDatasetMutation>> {
         return this.deleteDatasetGQL
             .mutate({
                 datasetId,
@@ -258,7 +259,7 @@ export class DatasetApi {
             );
     }
 
-    public renameDataset(datasetId: string, newName: string): Observable<RenameDatasetMutation | null | undefined> {
+    public renameDataset(datasetId: string, newName: string): Observable<MaybeNullOrUndefined<RenameDatasetMutation>> {
         return this.renameDatasetGQL
             .mutate({
                 datasetId,

--- a/src/app/api/kamu.graphql.interface.ts
+++ b/src/app/api/kamu.graphql.interface.ts
@@ -14,21 +14,21 @@ export type Scalars = {
     Boolean: boolean;
     Int: number;
     Float: number;
-    AccountID: any;
-    AccountName: any;
-    DatasetAlias: any;
-    DatasetID: any;
-    DatasetName: any;
-    DatasetRef: any;
-    DatasetRefAny: any;
+    AccountID: string;
+    AccountName: string;
+    DatasetAlias: string;
+    DatasetID: string;
+    DatasetName: string;
+    DatasetRef: string;
+    DatasetRefAny: string;
     /**
      * Implement the DateTime<Utc> scalar
      *
      * The input/output is a string in RFC3339 format.
      */
-    DateTime: any;
-    Multihash: any;
-    TaskID: any;
+    DateTime: string;
+    Multihash: string;
+    TaskID: string;
 };
 
 export type AccessToken = {
@@ -1112,7 +1112,12 @@ export type CommitEventToDatasetMutation = {
                     __typename?: "MetadataChainMut";
                     commitEvent:
                         | { __typename: "CommitResultAppendError"; message: string }
-                        | { __typename: "CommitResultSuccess"; message: string; oldHead?: any | null; newHead: any }
+                        | {
+                              __typename: "CommitResultSuccess";
+                              message: string;
+                              oldHead?: string | null;
+                              newHead: string;
+                          }
                         | { __typename: "MetadataManifestMalformed"; message: string }
                         | { __typename: "MetadataManifestUnsupportedVersion" }
                         | { __typename: "NoChanges" };
@@ -1176,7 +1181,7 @@ export type UpdateReadmeMutation = {
                 __typename?: "DatasetMetadataMut";
                 updateReadme:
                     | { __typename: "CommitResultAppendError"; message: string }
-                    | { __typename: "CommitResultSuccess"; oldHead?: any | null; message: string }
+                    | { __typename: "CommitResultSuccess"; oldHead?: string | null; message: string }
                     | { __typename: "NoChanges"; message: string };
             };
         } | null;
@@ -1321,10 +1326,10 @@ export type DeleteDatasetMutation = {
                 | {
                       __typename?: "DeleteResultDanglingReference";
                       message: string;
-                      danglingChildRefs: Array<any>;
-                      notDeletedDataset: any;
+                      danglingChildRefs: Array<string>;
+                      notDeletedDataset: string;
                   }
-                | { __typename?: "DeleteResultSuccess"; message: string; deletedDataset: any };
+                | { __typename?: "DeleteResultSuccess"; message: string; deletedDataset: string };
         } | null;
     };
 };
@@ -1341,38 +1346,38 @@ export type EnginesQuery = {
 
 export type AddDataEventFragment = {
     __typename?: "AddData";
-    inputCheckpoint?: any | null;
-    addDataWatermark?: any | null;
+    inputCheckpoint?: string | null;
+    addDataWatermark?: string | null;
     outputData?: {
         __typename?: "DataSlice";
-        logicalHash: any;
-        physicalHash: any;
+        logicalHash: string;
+        physicalHash: string;
         size: number;
         interval: { __typename?: "OffsetInterval"; start: number; end: number };
     } | null;
-    outputCheckpoint?: { __typename?: "Checkpoint"; physicalHash: any; size: number } | null;
+    outputCheckpoint?: { __typename?: "Checkpoint"; physicalHash: string; size: number } | null;
 };
 
 export type ExecuteQueryEventFragment = {
     __typename?: "ExecuteQuery";
-    inputCheckpoint?: any | null;
-    watermark?: any | null;
+    inputCheckpoint?: string | null;
+    watermark?: string | null;
     queryOutputData?: {
         __typename?: "DataSlice";
-        logicalHash: any;
-        physicalHash: any;
+        logicalHash: string;
+        physicalHash: string;
         interval: { __typename?: "OffsetInterval"; start: number; end: number };
     } | null;
     inputSlices: Array<{
         __typename?: "InputSlice";
-        datasetId: any;
-        blockInterval?: { __typename?: "BlockInterval"; start: any; end: any } | null;
+        datasetId: string;
+        blockInterval?: { __typename?: "BlockInterval"; start: string; end: string } | null;
         dataInterval?: { __typename?: "OffsetInterval"; start: number; end: number } | null;
     }>;
-    outputCheckpoint?: { __typename?: "Checkpoint"; physicalHash: any; size: number } | null;
+    outputCheckpoint?: { __typename?: "Checkpoint"; physicalHash: string; size: number } | null;
 };
 
-export type SeedEventFragment = { __typename?: "Seed"; datasetId: any; datasetKind: DatasetKind };
+export type SeedEventFragment = { __typename?: "Seed"; datasetId: string; datasetKind: DatasetKind };
 
 export type SetAttachmentsEventFragment = {
     __typename?: "SetAttachments";
@@ -1487,7 +1492,7 @@ export type SetVocabEventFragment = {
     offsetColumn?: string | null;
 };
 
-export type SetWatermarkEventFragment = { __typename?: "SetWatermark"; outputWatermark: any };
+export type SetWatermarkEventFragment = { __typename?: "SetWatermark"; outputWatermark: string };
 
 export type AccountDetailsFragment = {
     __typename?: "AccountInfo";
@@ -1506,10 +1511,12 @@ export type DataQueryResultSuccessViewFragment = {
 
 export type DatasetBasicsFragment = {
     __typename?: "Dataset";
-    id: any;
+    id: string;
     kind: DatasetKind;
-    name: any;
-    owner: { __typename?: "Organization"; id: any; name: string } | { __typename?: "User"; id: any; name: string };
+    name: string;
+    owner:
+        | { __typename?: "Organization"; id: string; name: string }
+        | { __typename?: "User"; id: string; name: string };
 };
 
 export type DatasetCurrentInfoFragment = {
@@ -1542,12 +1549,12 @@ export type DatasetDescriptionFragment = {
 export type DatasetDetailsFragment = {
     __typename?: "Dataset";
     kind: DatasetKind;
-    createdAt: any;
-    lastUpdatedAt: any;
+    createdAt: string;
+    lastUpdatedAt: string;
     data: { __typename?: "DatasetData"; estimatedSize: number; numRecordsTotal: number };
     metadata: {
         __typename?: "DatasetMetadata";
-        currentWatermark?: any | null;
+        currentWatermark?: string | null;
         currentLicense?: ({ __typename?: "SetLicense" } & LicenseFragment) | null;
     };
 };
@@ -1649,7 +1656,7 @@ export type DatasetMetadataSummaryFragment = {
     __typename?: "Dataset";
     metadata: {
         __typename: "DatasetMetadata";
-        currentWatermark?: any | null;
+        currentWatermark?: string | null;
         currentInfo: { __typename?: "SetInfo" } & DatasetCurrentInfoFragment;
         currentLicense?: ({ __typename?: "SetLicense" } & LicenseFragment) | null;
         currentSource?: ({ __typename?: "SetPollingSource" } & SetPollingSourceEventFragment) | null;
@@ -1688,13 +1695,13 @@ export type DatasetReadmeFragment = {
 
 export type DatasetSearchOverviewFragment = {
     __typename?: "Dataset";
-    createdAt: any;
-    lastUpdatedAt: any;
+    createdAt: string;
+    lastUpdatedAt: string;
     metadata: {
         __typename?: "DatasetMetadata";
         currentInfo: { __typename?: "SetInfo" } & DatasetCurrentInfoFragment;
         currentLicense?: ({ __typename?: "SetLicense" } & LicenseFragment) | null;
-        currentDownstreamDependencies: Array<{ __typename?: "Dataset"; id: any; kind: DatasetKind }>;
+        currentDownstreamDependencies: Array<{ __typename?: "Dataset"; id: string; kind: DatasetKind }>;
     };
 } & DatasetBasicsFragment;
 
@@ -1710,8 +1717,8 @@ export type DatasetTransformFragment = {
     __typename?: "SetTransform";
     inputs: Array<{
         __typename?: "TransformInput";
-        name: any;
-        datasetRef?: any | null;
+        name: string;
+        datasetRef?: string | null;
         dataset: { __typename?: "Dataset" } & DatasetBasicsFragment;
     }>;
     transform: { __typename?: "TransformSql" } & DatasetTransformContentFragment;
@@ -1727,11 +1734,11 @@ export type LicenseFragment = {
 
 export type MetadataBlockFragment = {
     __typename?: "MetadataBlockExtended";
-    blockHash: any;
-    prevBlockHash?: any | null;
-    systemTime: any;
+    blockHash: string;
+    prevBlockHash?: string | null;
+    systemTime: string;
     sequenceNumber: number;
-    author: { __typename: "Organization"; id: any; name: string } | { __typename: "User"; id: any; name: string };
+    author: { __typename: "Organization"; id: string; name: string } | { __typename: "User"; id: string; name: string };
     event:
         | ({ __typename: "AddData" } & AddDataEventFragment)
         | ({ __typename: "ExecuteQuery" } & ExecuteQueryEventFragment)
@@ -1806,9 +1813,9 @@ export type RenameDatasetMutation = {
         byId?: {
             __typename?: "DatasetMut";
             rename:
-                | { __typename: "RenameResultNameCollision"; message: string; collidingAlias: any }
-                | { __typename: "RenameResultNoChanges"; preservedName: any; message: string }
-                | { __typename: "RenameResultSuccess"; message: string; oldName: any; newName: any };
+                | { __typename: "RenameResultNameCollision"; message: string; collidingAlias: string }
+                | { __typename: "RenameResultNoChanges"; preservedName: string; message: string }
+                | { __typename: "RenameResultSuccess"; message: string; oldName: string; newName: string };
         } | null;
     };
 };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -139,14 +139,14 @@ describe("AppComponent", () => {
         component.onSelectDataset(mockAutocompleteItems[0]);
         expect(navigateToDatasetViewSpy).toHaveBeenCalledWith({
             accountName: mockAutocompleteItems[0].dataset.owner.name,
-            datasetName: mockAutocompleteItems[0].dataset.name as string,
+            datasetName: mockAutocompleteItems[0].dataset.name ,
         });
     });
 
     it("should check call onSelectDataset method and navigate to search", () => {
         const navigateToSearchSpy = spyOn(navigationService, "navigateToSearch").and.returnValue();
         component.onSelectDataset(mockAutocompleteItems[1]);
-        expect(navigateToSearchSpy).toHaveBeenCalledWith(mockAutocompleteItems[1].dataset.id as string);
+        expect(navigateToSearchSpy).toHaveBeenCalledWith(mockAutocompleteItems[1].dataset.id );
     });
 
     it("should check call onUserProfile", () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -94,10 +94,10 @@ export class AppComponent extends BaseComponent implements OnInit {
         if (item.__typename === TypeNames.datasetType) {
             this.navigationService.navigateToDatasetView({
                 accountName: item.dataset.owner.name,
-                datasetName: item.dataset.name as string,
+                datasetName: item.dataset.name ,
             });
         } else {
-            this.navigationService.navigateToSearch(item.dataset.id as string);
+            this.navigationService.navigateToSearch(item.dataset.id );
         }
     }
     public onClickAppLogo(): void {

--- a/src/app/auth/account/additional-components/datasets-tab/datasets-tab.component.spec.ts
+++ b/src/app/auth/account/additional-components/datasets-tab/datasets-tab.component.spec.ts
@@ -51,7 +51,7 @@ describe("DatasetsTabComponent", () => {
         component.onSelectDataset(mockDatasetListItem);
         expect(navigateToDatasetViewSpy).toHaveBeenCalledWith({
             accountName: mockDatasetListItem.owner.name,
-            datasetName: mockDatasetListItem.name as string,
+            datasetName: mockDatasetListItem.name ,
         });
     });
 

--- a/src/app/auth/account/additional-components/datasets-tab/datasets-tab.component.ts
+++ b/src/app/auth/account/additional-components/datasets-tab/datasets-tab.component.ts
@@ -23,7 +23,7 @@ export class DatasetsTabComponent {
     public onSelectDataset(row: DatasetSearchOverviewFragment): void {
         this.navigationService.navigateToDatasetView({
             accountName: (row.owner as User).name,
-            datasetName: row.name as string,
+            datasetName: row.name ,
         });
     }
 

--- a/src/app/common/app.helpers.ts
+++ b/src/app/common/app.helpers.ts
@@ -1,5 +1,5 @@
 import moment from "moment";
-import { MaybeNull } from "./app.types";
+import { MaybeNull, MaybeNullOrUndefined } from "./app.types";
 import { DataSchema } from "../api/kamu.graphql.interface";
 import { DatasetSchema } from "../interface/dataset.interface";
 
@@ -56,6 +56,6 @@ export function momentConvertDatetoLocalWithFormat(dateParams: {
     return moment(ISOStringDate).format(dateParams.format);
 }
 
-export function parseCurrentSchema(data: MaybeNull<DataSchema | undefined>): MaybeNull<DatasetSchema> {
+export function parseCurrentSchema(data: MaybeNullOrUndefined<DataSchema>): MaybeNull<DatasetSchema> {
     return data ? (JSON.parse(data.content) as DatasetSchema) : null;
 }

--- a/src/app/common/app.types.ts
+++ b/src/app/common/app.types.ts
@@ -1,2 +1,3 @@
 export type MaybeNull<T> = T | null;
 export type MaybeUndefined<T> = T | undefined;
+export type MaybeNullOrUndefined<T> = T | null | undefined;

--- a/src/app/common/base-yaml-event.service.ts
+++ b/src/app/common/base-yaml-event.service.ts
@@ -7,6 +7,7 @@ import { BlockService } from "../dataset-block/metadata-block/block.service";
 import { SupportedEvents } from "../dataset-block/metadata-block/components/event-details/supported.events";
 import { DatasetHistoryUpdate } from "../dataset-view/dataset.subscriptions.interface";
 import { DatasetInfo } from "../interface/navigation.interface";
+import { MaybeNullOrUndefined } from "./app.types";
 
 export abstract class BaseYamlEventService {
     private appDatasetService = inject(DatasetService);
@@ -22,7 +23,7 @@ export abstract class BaseYamlEventService {
         return this.kindChanges$.asObservable();
     }
 
-    public getEventAsYaml(info: DatasetInfo, typename: SupportedEvents): Observable<string | null | undefined> {
+    public getEventAsYaml(info: DatasetInfo, typename: SupportedEvents): Observable<MaybeNullOrUndefined<string>> {
         return this.appDatasetService.getDatasetHistory(info, this.historyPageSize, this.currentPage).pipe(
             expand((h: DatasetHistoryUpdate) => {
                 const filteredHistory = this.filterHistoryByType(h.history, typename);
@@ -44,7 +45,7 @@ export abstract class BaseYamlEventService {
                     of(null),
                     zip(
                         this.blockService.onMetadataBlockAsYamlChanges,
-                        this.blockService.requestMetadataBlock(info, filteredHistory[0]?.blockHash as string),
+                        this.blockService.requestMetadataBlock(info, filteredHistory[0]?.blockHash),
                     ),
                 ),
             ),

--- a/src/app/common/base-yaml-event.service.ts
+++ b/src/app/common/base-yaml-event.service.ts
@@ -7,7 +7,7 @@ import { BlockService } from "../dataset-block/metadata-block/block.service";
 import { SupportedEvents } from "../dataset-block/metadata-block/components/event-details/supported.events";
 import { DatasetHistoryUpdate } from "../dataset-view/dataset.subscriptions.interface";
 import { DatasetInfo } from "../interface/navigation.interface";
-import { MaybeNullOrUndefined } from "./app.types";
+import { MaybeNull, MaybeNullOrUndefined } from "./app.types";
 
 export abstract class BaseYamlEventService {
     private appDatasetService = inject(DatasetService);
@@ -49,7 +49,7 @@ export abstract class BaseYamlEventService {
                     ),
                 ),
             ),
-            map((result: [string, unknown] | null) => {
+            map((result: MaybeNull<[string, unknown]>) => {
                 if (result) return result[0];
                 else return null;
             }),

--- a/src/app/common/data.helpers.spec.ts
+++ b/src/app/common/data.helpers.spec.ts
@@ -186,7 +186,7 @@ it("should check description for SetWatermark block", () => {
         ...metadataBlockSetVocab,
         event: {
             __typename: "SetWatermark",
-            outputWatermark: +watermarkTime,
+            outputWatermark: watermarkTime.toString(),
         },
     };
     expect(DataHelpers.descriptionForMetadataBlock(setWatermarkBlock)).toEqual(`Watermark updated`);

--- a/src/app/common/data.helpers.ts
+++ b/src/app/common/data.helpers.ts
@@ -4,6 +4,7 @@ import { DatasetKind, MetadataBlockFragment } from "../api/kamu.graphql.interfac
 import { EventPropertyLogo } from "../dataset-block/metadata-block/components/event-details/supported.events";
 import { JsonFormValidators } from "../dataset-view/additional-components/metadata-component/components/add-polling-source/add-polling-source-form.types";
 import { SetPollingSourceSection } from "../shared/shared.types";
+import { MaybeUndefined } from "./app.types";
 
 export class DataHelpers {
     public static readonly BLOCK_DESCRIBE_SEED = "Dataset initialized";
@@ -49,7 +50,7 @@ export class DataHelpers {
         }
     }
 
-    public static descriptionMergeStrategy(type: string | undefined): EventPropertyLogo {
+    public static descriptionMergeStrategy(type: MaybeUndefined<string>): EventPropertyLogo {
         switch (type) {
             case "MergeStrategyLedger":
                 return {

--- a/src/app/components/app-header/app-header.component.ts
+++ b/src/app/components/app-header/app-header.component.ts
@@ -1,3 +1,4 @@
+import { MaybeNull } from "./../../common/app.types";
 import { ActivatedRoute, NavigationEnd, Params, Router, RouterEvent } from "@angular/router";
 import {
     ChangeDetectionStrategy,
@@ -105,7 +106,7 @@ export class AppHeaderComponent extends BaseComponent implements OnInit {
     }
 
     public onClickInput(): void {
-        const typeaheadInput: HTMLElement | null = document.getElementById("typeahead-http");
+        const typeaheadInput: MaybeNull<HTMLElement> = document.getElementById("typeahead-http");
         if (typeaheadInput) {
             typeaheadInput.focus();
         }
@@ -116,7 +117,7 @@ export class AppHeaderComponent extends BaseComponent implements OnInit {
         if (event.item) {
             this.selectDatasetEmitter.emit(event.item as DatasetAutocompleteItem);
             setTimeout(() => {
-                const typeaheadInput: HTMLElement | null = document.getElementById("typeahead-http");
+                const typeaheadInput: MaybeNull<HTMLElement> = document.getElementById("typeahead-http");
                 if (typeaheadInput) {
                     typeaheadInput.blur();
                 }
@@ -125,7 +126,7 @@ export class AppHeaderComponent extends BaseComponent implements OnInit {
     }
 
     public toggleAppHeaderMenu(): void {
-        const appHeaderButton: HTMLElement | null = document.getElementById("app-header");
+        const appHeaderButton: MaybeNull<HTMLElement> = document.getElementById("app-header");
 
         this.isCollapsedAppHeaderMenu = !this.isCollapsedAppHeaderMenu;
         if (appHeaderButton) {

--- a/src/app/components/app-header/app-header.component.ts
+++ b/src/app/components/app-header/app-header.component.ts
@@ -101,7 +101,7 @@ export class AppHeaderComponent extends BaseComponent implements OnInit {
     };
 
     public formatter(x: DatasetAutocompleteItem | string): string {
-        return typeof x !== "string" ? (x.dataset.name as string) : x;
+        return typeof x !== "string" ? x.dataset.name : x;
     }
 
     public onClickInput(): void {

--- a/src/app/components/dataset-list-component/dataset-list.component.ts
+++ b/src/app/components/dataset-list-component/dataset-list.component.ts
@@ -28,7 +28,7 @@ export class DatasetListComponent {
     public onSelectDataset(row: DatasetSearchOverviewFragment): void {
         const datasetBasics: DatasetBasicsFragment = row as DatasetBasicsFragment;
         this.selectDatasetEmit.emit({
-            datasetName: datasetBasics.name as string,
+            datasetName: datasetBasics.name,
             accountName: datasetBasics.owner.name,
         });
     }

--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -17,6 +17,7 @@ import { ModalSpinnerComponent } from "./modal-spinner.component";
 import { Location } from "@angular/common";
 import { ModalMappingsComponent } from "../../interface/modal.interface";
 import { BaseComponent } from "src/app/common/base.component";
+import { MaybeUndefined } from "src/app/common/app.types";
 
 @Component({
     selector: "modal",
@@ -28,7 +29,7 @@ export class ModalComponent extends BaseComponent implements OnInit {
     @ViewChild("container", { read: ViewContainerRef })
     container: ViewContainerRef;
     isVisible: boolean;
-    type: string | undefined;
+    type: MaybeUndefined<string>;
 
     private componentRef: ComponentRef<unknown>;
     private mappings: ModalMappingsComponent = {

--- a/src/app/components/overview-history-summary-header/overview-history-summary-header.component.spec.ts
+++ b/src/app/components/overview-history-summary-header/overview-history-summary-header.component.spec.ts
@@ -46,11 +46,16 @@ describe("OverviewHistorySummaryHeaderComponent", () => {
     });
 
     it("should navigate to metadata block", () => {
+        if (!component.metadataBlockFragment) {
+            fail("unexpected state");
+            return;
+        }
+
         const navigateToMetadataBlockSpy = spyOn(navigationService, "navigateToMetadataBlock");
         const params: MetadataBlockNavigationParams = {
             accountName: component.authorInfo.name,
             datasetName: component.datasetName,
-            blockHash: component.metadataBlockFragment?.blockHash as string,
+            blockHash: component.metadataBlockFragment.blockHash,
         };
 
         emitClickOnElementByDataTestId(fixture, "navigate-to-metadata-block");

--- a/src/app/components/overview-history-summary-header/overview-history-summary-header.component.ts
+++ b/src/app/components/overview-history-summary-header/overview-history-summary-header.component.ts
@@ -19,7 +19,7 @@ export class OverviewHistorySummaryHeaderComponent {
     constructor(private navigationService: NavigationService) {}
 
     get systemTime(): string {
-        return this.metadataBlockFragment ? (this.metadataBlockFragment.systemTime as string) : "";
+        return this.metadataBlockFragment ? this.metadataBlockFragment.systemTime : "";
     }
 
     get authorInfo(): Account {

--- a/src/app/components/timeline-component/timeline.component.spec.ts
+++ b/src/app/components/timeline-component/timeline.component.spec.ts
@@ -67,7 +67,7 @@ describe("TimelineComponent", () => {
         const params: MetadataBlockNavigationParams = {
             accountName: component.history[0].author.name,
             datasetName: component.datasetName,
-            blockHash: component.history[0].blockHash as string,
+            blockHash: component.history[0].blockHash ,
         };
 
         emitClickOnElementByDataTestId(fixture, "navigate-to-block");

--- a/src/app/dataset-block/metadata-block/block.service.ts
+++ b/src/app/dataset-block/metadata-block/block.service.ts
@@ -3,6 +3,7 @@ import { Subject, Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { DatasetApi } from "src/app/api/dataset.api";
 import { GetMetadataBlockQuery, MetadataBlockFragment } from "src/app/api/kamu.graphql.interface";
+import { MaybeUndefined } from "src/app/common/app.types";
 import { DatasetInfo } from "src/app/interface/navigation.interface";
 
 @Injectable({
@@ -36,9 +37,8 @@ export class BlockService {
             map((data: GetMetadataBlockQuery) => {
                 if (data.datasets.byOwnerAndName) {
                     const block = data.datasets.byOwnerAndName.metadata.chain.blockByHash as MetadataBlockFragment;
-                    const blockAsYaml = data.datasets.byOwnerAndName.metadata.chain.blockByHashEncoded as
-                        | string
-                        | undefined;
+                    const blockAsYaml = data.datasets.byOwnerAndName.metadata.chain
+                        .blockByHashEncoded as MaybeUndefined<string>;
                     this.metadataBlockChanges(block);
                     if (blockAsYaml) {
                         this.metadataBlockAsYamlChanges(blockAsYaml);

--- a/src/app/dataset-block/metadata-block/components/block-header/block-header.component.html
+++ b/src/app/dataset-block/metadata-block/components/block-header/block-header.component.html
@@ -40,7 +40,7 @@
 
             <app-block-row-data tooltip="Hash sum of the preceding block." label="Previous Block Hash:">
                 <app-display-hash
-                    [value]="block.prevBlockHash"
+                    [value]="block.prevBlockHash ?? 'None'"
                     [navigationTargetDataset]="datasetInfo"
                     [showCopyButton]="true"
                 ></app-display-hash>

--- a/src/app/dataset-block/metadata-block/components/block-navigation/pipes/block-hash-filter.pipe.ts
+++ b/src/app/dataset-block/metadata-block/components/block-navigation/pipes/block-hash-filter.pipe.ts
@@ -7,6 +7,6 @@ import { MetadataBlockFragment } from "src/app/api/kamu.graphql.interface";
 export class BlockHashFilterPipe implements PipeTransform {
     transform(blocks: MetadataBlockFragment[], filter: string): MetadataBlockFragment[] {
         if (filter === "") return blocks;
-        return blocks.filter((block: MetadataBlockFragment) => (block.blockHash as string).includes(filter));
+        return blocks.filter((block: MetadataBlockFragment) => (block.blockHash ).includes(filter));
     }
 }

--- a/src/app/dataset-block/metadata-block/components/event-details/components/common/block-interval-property/block-interval-property.component.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/common/block-interval-property/block-interval-property.component.ts
@@ -23,7 +23,7 @@ export class BlockIntervalPropertyComponent extends BasePropertyComponent implem
             this.datasetSevice.requestDatasetInfoById(this.data.datasetId).subscribe((dataset: DatasetByIdQuery) => {
                 if (dataset.datasets.byId) {
                     this.datasetInfo.accountName = dataset.datasets.byId.owner.name;
-                    this.datasetInfo.datasetName = dataset.datasets.byId.name as string;
+                    this.datasetInfo.datasetName = dataset.datasets.byId.name ;
                 }
             }),
         );

--- a/src/app/dataset-block/metadata-block/components/event-details/components/common/dataset-name-by-id-property/dataset-name-by-id-property.component.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/common/dataset-name-by-id-property/dataset-name-by-id-property.component.ts
@@ -29,7 +29,7 @@ export class DatasetNameByIdPropertyComponent extends BasePropertyComponent impl
             this.datasetSevice.requestDatasetInfoById(this.data).subscribe((dataset: DatasetByIdQuery) => {
                 if (dataset.datasets.byId) {
                     this.datasetInfo.accountName = dataset.datasets.byId.owner.name;
-                    this.datasetInfo.datasetName = dataset.datasets.byId.name as string;
+                    this.datasetInfo.datasetName = dataset.datasets.byId.name ;
                     this.cdr.detectChanges();
                 }
             }),

--- a/src/app/dataset-block/metadata-block/components/event-details/components/common/offset-interval-property/offset-interval-property.component.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/common/offset-interval-property/offset-interval-property.component.ts
@@ -30,7 +30,7 @@ export class OffsetIntervalPropertyComponent extends BasePropertyComponent imple
                     .subscribe((dataset: DatasetByIdQuery) => {
                         if (dataset.datasets.byId) {
                             this.datasetInfo.accountName = dataset.datasets.byId.owner.name;
-                            this.datasetInfo.datasetName = dataset.datasets.byId.name as string;
+                            this.datasetInfo.datasetName = dataset.datasets.byId.name ;
                         }
                     }),
             );

--- a/src/app/dataset-block/metadata-block/components/event-details/components/common/offset-interval-property/offset-interval-property.component.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/common/offset-interval-property/offset-interval-property.component.ts
@@ -6,6 +6,7 @@ import { OffsetInterval } from "src/app/api/kamu.graphql.interface";
 import { DatasetInfo } from "src/app/interface/navigation.interface";
 import { DatasetViewTypeEnum } from "src/app/dataset-view/dataset-view.interface";
 import { DatasetService } from "src/app/dataset-view/dataset.service";
+import { MaybeNull } from "src/app/common/app.types";
 
 @Component({
     selector: "app-interval-property",
@@ -16,7 +17,7 @@ import { DatasetService } from "src/app/dataset-view/dataset.service";
 export class OffsetIntervalPropertyComponent extends BasePropertyComponent implements OnInit {
     @Input() public data: {
         block: OffsetInterval;
-        datasetId: string | null;
+        datasetId: MaybeNull<string>;
     };
     private datasetInfo: DatasetInfo = { accountName: "", datasetName: "" };
     constructor(private navigationService: NavigationService, private datasetSevice: DatasetService) {
@@ -30,7 +31,7 @@ export class OffsetIntervalPropertyComponent extends BasePropertyComponent imple
                     .subscribe((dataset: DatasetByIdQuery) => {
                         if (dataset.datasets.byId) {
                             this.datasetInfo.accountName = dataset.datasets.byId.owner.name;
-                            this.datasetInfo.datasetName = dataset.datasets.byId.name ;
+                            this.datasetInfo.datasetName = dataset.datasets.byId.name;
                         }
                     }),
             );

--- a/src/app/dataset-block/metadata-block/components/event-details/dynamic-events/builders/execute-query.section.builder.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/dynamic-events/builders/execute-query.section.builder.ts
@@ -82,7 +82,7 @@ export class ExecuteQuerySectionBuilder extends EventSectionBuilder<ExecuteQuery
                         (data as InputSlice[]).forEach((item, index) => {
                             let rows: EventRow[] = [];
                             Object.entries({
-                                id: item.datasetId as string,
+                                id: item.datasetId,
                                 ...item,
                             }).forEach(([key, value]) => {
                                 if (event.__typename && item.__typename && key !== "__typename") {
@@ -129,7 +129,7 @@ export class ExecuteQuerySectionBuilder extends EventSectionBuilder<ExecuteQuery
             case "dataInterval":
                 return {
                     block: value,
-                    datasetId: inputItem?.datasetId as string,
+                    datasetId: inputItem?.datasetId ?? null,
                 };
             case "interval":
                 return {

--- a/src/app/dataset-block/metadata-block/components/event-details/dynamic-events/builders/set-transform-section.builder.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/dynamic-events/builders/set-transform-section.builder.ts
@@ -30,12 +30,12 @@ export class SetTransformSectionBuilder extends EventSectionBuilder<SetTransform
                             const object = item.datasetRef
                                 ? {
                                       ...item.dataset,
-                                      alias: item.name as string,
-                                      datasetRef: item.datasetRef as string,
+                                      alias: item.name ,
+                                      datasetRef: item.datasetRef ,
                                   }
                                 : {
                                       ...item.dataset,
-                                      alias: item.name as string,
+                                      alias: item.name ,
                                   };
                             Object.entries(object).forEach(([key, value]) => {
                                 if (event.__typename && item.dataset.__typename && key !== "__typename") {

--- a/src/app/dataset-block/metadata-block/components/yaml-view-section/yaml-view-section.component.spec.ts
+++ b/src/app/dataset-block/metadata-block/components/yaml-view-section/yaml-view-section.component.spec.ts
@@ -6,6 +6,7 @@ import { mockGetMetadataBlockQuery } from "src/app/api/mock/dataset.mock";
 import { MetadataBlockFragment } from "src/app/api/kamu.graphql.interface";
 import { ChangeDetectionStrategy } from "@angular/core";
 import { SharedTestModule } from "src/app/common/shared-test.module";
+import { MaybeUndefined } from "src/app/common/app.types";
 
 describe("YamlViewSectionComponent", () => {
     let component: YamlViewSectionComponent;
@@ -43,9 +44,8 @@ describe("YamlViewSectionComponent", () => {
     });
 
     it("should check onMetadataBlockAsYamlChanges subscribe", () => {
-        const mockBlock = mockGetMetadataBlockQuery.datasets.byOwnerAndName?.metadata.chain.blockByHashEncoded as
-            | string
-            | undefined;
+        const mockBlock = mockGetMetadataBlockQuery.datasets.byOwnerAndName?.metadata.chain
+            .blockByHashEncoded as MaybeUndefined<string>;
         if (mockBlock) {
             blockService.metadataBlockAsYamlChanges(mockBlock);
             component.ngOnInit();

--- a/src/app/dataset-create/dataset-create.service.spec.ts
+++ b/src/app/dataset-create/dataset-create.service.spec.ts
@@ -95,7 +95,7 @@ describe("AppDatasetCreateService", () => {
 
         expect(spyNavigateToDatasetView).toHaveBeenCalledWith({
             accountName: mockDatasetInfo.accountName,
-            datasetName: mockDatasetBasicsFragment.name as string,
+            datasetName: mockDatasetBasicsFragment.name ,
             tab: DatasetViewTypeEnum.Overview,
         });
     });
@@ -116,7 +116,7 @@ describe("AppDatasetCreateService", () => {
 
         expect(spyNavigateToDatasetView).not.toHaveBeenCalledWith({
             accountName: mockDatasetInfo.accountName,
-            datasetName: mockDatasetBasicsFragment.name as string,
+            datasetName: mockDatasetBasicsFragment.name ,
             tab: DatasetViewTypeEnum.Overview,
         });
         service.onErrorMessageChanges.subscribe((error) => {

--- a/src/app/dataset-create/dataset-create.service.ts
+++ b/src/app/dataset-create/dataset-create.service.ts
@@ -6,6 +6,7 @@ import { DatasetKind } from "../api/kamu.graphql.interface";
 import { map } from "rxjs/operators";
 import { NavigationService } from "../services/navigation.service";
 import { DatasetViewTypeEnum } from "../dataset-view/dataset-view.interface";
+import { MaybeNullOrUndefined } from "../common/app.types";
 
 @Injectable({ providedIn: "root" })
 export class AppDatasetCreateService {
@@ -23,7 +24,7 @@ export class AppDatasetCreateService {
 
     public createEmptyDataset(accountId: string, datasetKind: DatasetKind, datasetName: string): Observable<void> {
         return this.datasetApi.createEmptyDataset(accountId, datasetKind, datasetName).pipe(
-            map((data: CreateEmptyDatasetMutation | null | undefined) => {
+            map((data: MaybeNullOrUndefined<CreateEmptyDatasetMutation>) => {
                 if (data?.datasets.createEmpty.__typename === "CreateDatasetResultSuccess") {
                     this.navigationService.navigateToDatasetView({
                         accountName: accountId,
@@ -39,9 +40,9 @@ export class AppDatasetCreateService {
 
     public createDatasetFromSnapshot(accountId: string, snapshot: string): Observable<void> {
         return this.datasetApi.createDatasetFromSnapshot(accountId, snapshot).pipe(
-            map((data: CreateDatasetFromSnapshotMutation | null | undefined) => {
+            map((data: MaybeNullOrUndefined<CreateDatasetFromSnapshotMutation>) => {
                 if (data?.datasets.createFromSnapshot.__typename === "CreateDatasetResultSuccess") {
-                    const datasetName = data.datasets.createFromSnapshot.dataset.name as string;
+                    const datasetName = data.datasets.createFromSnapshot.dataset.name;
                     this.navigationService.navigateToDatasetView({
                         accountName: accountId,
                         datasetName,

--- a/src/app/dataset-view/additional-components/data-component/data-component.ts
+++ b/src/app/dataset-view/additional-components/data-component/data-component.ts
@@ -97,7 +97,7 @@ export class DataComponent extends BaseComponent implements OnInit {
 
     private buildSqlRequestCode(): void {
         if (this.datasetBasics) {
-            this.sqlRequestCode += `'${this.datasetBasics.name as string}'`;
+            this.sqlRequestCode += `'${this.datasetBasics.name }'`;
             const offset = this.location.getState() as Partial<OffsetInterval>;
             if (typeof offset.start !== "undefined" && typeof offset.end !== "undefined") {
                 this.sqlRequestCode += `\nwhere ${this.offsetColumnName}>=${offset.start} and ${this.offsetColumnName}<=${offset.end}\norder by ${this.offsetColumnName} desc`;

--- a/src/app/dataset-view/additional-components/history-component/history-component.ts
+++ b/src/app/dataset-view/additional-components/history-component/history-component.ts
@@ -18,7 +18,7 @@ import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.serv
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HistoryComponent extends BaseComponent implements OnInit {
-    @Input() public datasetName: string;
+    @Input() public datasetName?: string;
     @Output() onPageChangeEmit = new EventEmitter<number>();
 
     public currentState?: {

--- a/src/app/dataset-view/additional-components/history-component/history.component.html
+++ b/src/app/dataset-view/additional-components/history-component/history.component.html
@@ -3,7 +3,7 @@
         <div *ngIf="currentPage > totalPages">
             The current page {{ currentPage }} is greater than the total number of pages {{ totalPages }}.
         </div>
-        <ng-template [ngIf]="currentState && currentState.history.length > 0">
+        <ng-template [ngIf]="datasetName && currentState && currentState.history.length > 0">
             <app-timeline
                 [datasetName]="datasetName"
                 [history]="currentState.history"

--- a/src/app/dataset-view/additional-components/lineage-component/lineage-component.ts
+++ b/src/app/dataset-view/additional-components/lineage-component/lineage-component.ts
@@ -76,7 +76,7 @@ export class LineageComponent extends BaseComponent implements OnInit {
                 }
 
                 if (cluster.label === dataset.kind) {
-                    cluster.childNodeIds.push(dataset.id as string);
+                    cluster.childNodeIds.push(dataset.id );
                 }
                 return cluster;
             });
@@ -92,17 +92,17 @@ export class LineageComponent extends BaseComponent implements OnInit {
         const uniqueDatasets: Record<string, DatasetBasicsFragment> = {};
         edges.forEach((edge: DatasetBasicsFragment[]) =>
             edge.forEach((dataset: DatasetBasicsFragment) => {
-                uniqueDatasets[dataset.id as string] = dataset;
+                uniqueDatasets[dataset.id ] = dataset;
             }),
         );
 
         for (const [id, dataset] of Object.entries(uniqueDatasets)) {
             this.lineageGraphNodes.push({
                 id: this.sanitizeID(id),
-                label: dataset.name as string,
+                label: dataset.name ,
                 data: {
-                    id: dataset.id as string,
-                    name: dataset.name as string,
+                    id: dataset.id ,
+                    name: dataset.name ,
                     kind: dataset.kind,
                     isRoot: dataset.kind === DatasetKind.Root,
                     isCurrent: dataset.id === currentDataset.id,
@@ -111,8 +111,8 @@ export class LineageComponent extends BaseComponent implements OnInit {
         }
 
         edges.forEach((edge: DatasetBasicsFragment[]) => {
-            const source: string = this.sanitizeID(edge[0].id as string);
-            const target: string = this.sanitizeID(edge[1].id as string);
+            const source: string = this.sanitizeID(edge[0].id );
+            const target: string = this.sanitizeID(edge[1].id );
 
             this.lineageGraphLink.push({
                 id: `${source}__and__${target}`,

--- a/src/app/dataset-view/additional-components/metadata-component/components/add-polling-source/add-polling-source.component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/components/add-polling-source/add-polling-source.component.ts
@@ -17,6 +17,7 @@ import { from } from "rxjs";
 import { SupportedEvents } from "src/app/dataset-block/metadata-block/components/event-details/supported.events";
 import { STEPPER_GLOBAL_OPTIONS } from "@angular/cdk/stepper";
 import { BaseMainEventComponent } from "../base-main-event.component";
+import { MaybeNullOrUndefined } from "src/app/common/app.types";
 
 @Component({
     selector: "app-add-polling-source",
@@ -93,7 +94,7 @@ export class AddPollingSourceComponent extends BaseMainEventComponent implements
         this.trackSubscriptions(
             this.editService
                 .getEventAsYaml(this.getDatasetInfoFromUrl(), SupportedEvents.SetPollingSource)
-                .subscribe((result: string | undefined | null) => {
+                .subscribe((result: MaybeNullOrUndefined<string>) => {
                     if (result) {
                         this.eventYamlByHash = result;
                     }

--- a/src/app/dataset-view/additional-components/metadata-component/components/set-transform/components/engine-section/engine-section.component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/components/set-transform/components/engine-section/engine-section.component.ts
@@ -7,8 +7,8 @@ import {
     OnInit,
     Output,
 } from "@angular/core";
-import { EngineDesc, EnginesQuery, Maybe, TransformSql } from "src/app/api/kamu.graphql.interface";
-import { MaybeNull } from "src/app/common/app.types";
+import { EngineDesc, EnginesQuery, TransformSql } from "src/app/api/kamu.graphql.interface";
+import { MaybeNull, MaybeNullOrUndefined } from "src/app/common/app.types";
 import { BaseComponent } from "src/app/common/base.component";
 import { EngineService } from "src/app/services/engine.service";
 
@@ -20,7 +20,7 @@ import { EngineService } from "src/app/services/engine.service";
 })
 export class EngineSectionComponent extends BaseComponent implements OnInit {
     @Input() public knownEngines: MaybeNull<EngineDesc[]>;
-    @Input() public currentSetTransformEvent: Maybe<TransformSql> | undefined;
+    @Input() public currentSetTransformEvent: MaybeNullOrUndefined<TransformSql>;
     @Input() public selectedEngine: string;
     @Output() public onEmitSelectedEngine: EventEmitter<string> = new EventEmitter<string>();
     public selectedImage: string;

--- a/src/app/dataset-view/additional-components/metadata-component/components/set-transform/components/search-section/search-section.component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/components/set-transform/components/search-section/search-section.component.ts
@@ -47,13 +47,13 @@ export class SearchSectionComponent extends BaseComponent {
     };
 
     public formatter(x: DatasetAutocompleteItem | string): string {
-        return typeof x !== "string" ? (x.dataset.name as string) : x;
+        return typeof x !== "string" ? (x.dataset.name ) : x;
     }
 
     public onSelectItem(event: NgbTypeaheadSelectItemEvent): void {
         const value = event.item as DatasetAutocompleteItem;
-        const id = value.dataset.id as string;
-        const name = value.dataset.name as string;
+        const id = value.dataset.id ;
+        const name = value.dataset.name ;
         const inputDataset = JSON.stringify({
             id,
             name,
@@ -68,7 +68,7 @@ export class SearchSectionComponent extends BaseComponent {
                             data.datasets.byId.metadata.currentSchema,
                         );
                         this.TREE_DATA.push({
-                            name: value.dataset.name as string,
+                            name: value.dataset.name ,
                             children: schema?.fields,
                             owner,
                         });

--- a/src/app/dataset-view/additional-components/metadata-component/metadata-component.spec.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata-component.spec.ts
@@ -89,7 +89,7 @@ describe("MetadataComponent", () => {
         component.navigateToEditPollingSource();
         expect(navigateToAddPollingSourceSpy).toHaveBeenCalledWith({
             accountName: mockDatasetBasicsFragment.owner.name,
-            datasetName: mockDatasetBasicsFragment.name as string,
+            datasetName: mockDatasetBasicsFragment.name ,
         });
     });
 
@@ -98,7 +98,7 @@ describe("MetadataComponent", () => {
         component.navigateToEditSetTransform();
         expect(navigateToSetTransformSpy).toHaveBeenCalledWith({
             accountName: mockDatasetBasicsFragment.owner.name,
-            datasetName: mockDatasetBasicsFragment.name as string,
+            datasetName: mockDatasetBasicsFragment.name ,
         });
     });
 });

--- a/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
@@ -80,12 +80,12 @@ export class MetadataComponent extends BaseComponent implements OnInit {
     }
 
     public get latestBlockhash(): string {
-        return this.currentState ? (this.currentState.metadata.metadata.chain.blocks.nodes[0].blockHash as string) : "";
+        return this.currentState ? this.currentState.metadata.metadata.chain.blocks.nodes[0].blockHash : "";
     }
 
     public get latestBlockSystemTime(): string {
-        const systemTimeAsString: string | undefined = this.currentState?.metadata.metadata.chain.blocks.nodes[0]
-            .systemTime as string;
+        const systemTimeAsString: string | undefined =
+            this.currentState?.metadata.metadata.chain.blocks.nodes[0].systemTime;
         return systemTimeAsString
             ? momentConvertDatetoLocalWithFormat({
                   date: new Date(String(systemTimeAsString)),
@@ -111,7 +111,7 @@ export class MetadataComponent extends BaseComponent implements OnInit {
         if (this.datasetBasics)
             this.navigationService.navigateToAddPollingSource({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: this.datasetBasics.name as string,
+                datasetName: this.datasetBasics.name,
             });
     }
 
@@ -119,7 +119,7 @@ export class MetadataComponent extends BaseComponent implements OnInit {
         if (this.datasetBasics)
             this.navigationService.navigateToSetTransform({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: this.datasetBasics.name as string,
+                datasetName: this.datasetBasics.name,
             });
     }
 }

--- a/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
+++ b/src/app/dataset-view/additional-components/metadata-component/metadata-component.ts
@@ -12,7 +12,7 @@ import {
     PageBasedInfo,
 } from "src/app/api/kamu.graphql.interface";
 import { momentConvertDatetoLocalWithFormat } from "src/app/common/app.helpers";
-import { MaybeNull } from "src/app/common/app.types";
+import { MaybeNull, MaybeUndefined } from "src/app/common/app.types";
 import { NavigationService } from "src/app/services/navigation.service";
 import { sqlEditorOptions } from "src/app/dataset-block/metadata-block/components/event-details/config-editor.events";
 
@@ -84,7 +84,7 @@ export class MetadataComponent extends BaseComponent implements OnInit {
     }
 
     public get latestBlockSystemTime(): string {
-        const systemTimeAsString: string | undefined =
+        const systemTimeAsString: MaybeUndefined<string> =
             this.currentState?.metadata.metadata.chain.blocks.nodes[0].systemTime;
         return systemTimeAsString
             ? momentConvertDatetoLocalWithFormat({

--- a/src/app/dataset-view/additional-components/overview-component/components/edit-details-modal/edit-details-modal.component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/components/edit-details-modal/edit-details-modal.component.ts
@@ -72,7 +72,7 @@ export class EditDetailsModalComponent extends BaseComponent implements OnInit {
                 this.datasetCommitService
                     .commitEventToDataset(
                         this.datasetBasics.owner.name,
-                        this.datasetBasics.name as string,
+                        this.datasetBasics.name,
                         this.yamlEventService.buildYamlSetInfoEvent(this.description, this.keywords),
                     )
                     .subscribe(),

--- a/src/app/dataset-view/additional-components/overview-component/components/edit-license-modal/edit-license-modal.component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/components/edit-license-modal/edit-license-modal.component.ts
@@ -62,7 +62,7 @@ export class EditLicenseModalComponent extends BaseComponent implements OnInit {
                 this.datasetCommitService
                     .commitEventToDataset(
                         this.datasetBasics.owner.name,
-                        this.datasetBasics.name as string,
+                        this.datasetBasics.name,
                         this.yamlEventService.buildYamlSetLicenseEvent(
                             this.licenseForm.value as Omit<SetLicense, "__typename">,
                         ),

--- a/src/app/dataset-view/additional-components/overview-component/components/edit-watermark-modal/edit-watermark-modal.component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/components/edit-watermark-modal/edit-watermark-modal.component.ts
@@ -1,4 +1,4 @@
-import { MaybeNull } from "./../../../../../common/app.types";
+import { MaybeNullOrUndefined } from "./../../../../../common/app.types";
 import { ChangeDetectionStrategy, Component, Input, OnInit } from "@angular/core";
 import { OWL_DATE_TIME_FORMATS } from "@danielmoncada/angular-datetime-picker";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
@@ -17,7 +17,7 @@ import { DatasetCommitService } from "../../services/dataset-commit.service";
     providers: [{ provide: OWL_DATE_TIME_FORMATS, useValue: MY_MOMENT_FORMATS }],
 })
 export class EditWatermarkModalComponent extends BaseComponent implements OnInit {
-    @Input() public currentWatermark: MaybeNull<string>;
+    @Input() public currentWatermark: MaybeNullOrUndefined<string>;
     @Input() public datasetBasics?: DatasetBasicsFragment;
     public date: Date;
     public timeZone = this.currentTimeZone;
@@ -64,7 +64,7 @@ export class EditWatermarkModalComponent extends BaseComponent implements OnInit
                 this.datasetCommitService
                     .commitEventToDataset(
                         this.datasetBasics.owner.name,
-                        this.datasetBasics.name as string,
+                        this.datasetBasics.name,
                         this.yamlEventService.buildYamlSetWatermarkEvent(date),
                     )
                     .subscribe(),

--- a/src/app/dataset-view/additional-components/overview-component/components/readme-section/readme-section.component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/components/readme-section/readme-section.component.ts
@@ -60,7 +60,7 @@ export class ReadmeSectionComponent extends BaseComponent implements OnInit {
         if (this.datasetBasics)
             this.trackSubscription(
                 this.datasetCommitService
-                    .updateReadme(this.datasetBasics.owner.name, this.datasetBasics.name as string, this.readmeState)
+                    .updateReadme(this.datasetBasics.owner.name, this.datasetBasics.name, this.readmeState)
                     .subscribe(() => {
                         this.reset();
                     }),

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.spec.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.spec.ts
@@ -106,7 +106,7 @@ describe("OverviewComponent", () => {
         component.navigateToAddPollingSource();
         expect(navigateToAddPollingSourceSpy).toHaveBeenCalledWith({
             accountName: mockDatasetBasicsFragment.owner.name,
-            datasetName: mockDatasetBasicsFragment.name as string,
+            datasetName: mockDatasetBasicsFragment.name ,
         });
     });
 });

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../api/kamu.graphql.interface";
 import { AppDatasetSubscriptionsService } from "../../dataset.subscriptions.service";
 import { DataRow, DatasetSchema } from "src/app/interface/dataset.interface";
-import { MaybeNull } from "src/app/common/app.types";
+import { MaybeNull, MaybeUndefined } from "src/app/common/app.types";
 import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { EditDetailsModalComponent } from "./components/edit-details-modal/edit-details-modal.component";
 import { EditWatermarkModalComponent } from "./components/edit-watermark-modal/edit-watermark-modal.component";
@@ -81,7 +81,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
         return DataHelpers.capitalizeFirstLetter(kind);
     }
 
-    get metadataFragmentBlock(): MetadataBlockFragment | undefined {
+    get metadataFragmentBlock(): MaybeUndefined<MetadataBlockFragment> {
         return this.currentState ? this.currentState.overview.metadata.chain.blocks.nodes[0] : undefined;
     }
 

--- a/src/app/dataset-view/additional-components/overview-component/overview-component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview-component.ts
@@ -102,7 +102,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
     public openWatermarkModal(): void {
         const modalRef: NgbModalRef = this.modalService.open(EditWatermarkModalComponent);
         const modalRefInstance = modalRef.componentInstance as EditWatermarkModalComponent;
-        modalRefInstance.currentWatermark = this.currentState?.overview.metadata.currentWatermark as string;
+        modalRefInstance.currentWatermark = this.currentState?.overview.metadata.currentWatermark;
         modalRefInstance.datasetBasics = this.datasetBasics;
     }
 
@@ -110,7 +110,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
         if (this.datasetBasics)
             this.navigationService.navigateToAddPollingSource({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: this.datasetBasics.name as string,
+                datasetName: this.datasetBasics.name,
             });
     }
 
@@ -118,7 +118,7 @@ export class OverviewComponent extends BaseComponent implements OnInit {
         if (this.datasetBasics)
             this.navigationService.navigateToSetTransform({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: this.datasetBasics.name as string,
+                datasetName: this.datasetBasics.name,
             });
     }
 

--- a/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.spec.ts
+++ b/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.spec.ts
@@ -1,3 +1,4 @@
+import { MaybeUndefined } from "./../../../../common/app.types";
 import { TestBed, fakeAsync, flush, tick } from "@angular/core/testing";
 import { DatasetCommitService } from "./dataset-commit.service";
 import { Apollo, ApolloModule } from "apollo-angular";
@@ -55,7 +56,7 @@ describe("DatasetCommitService", () => {
         expect(commitService).toBeTruthy();
     });
 
-    function requestDatasetId(): Observable<string | undefined> {
+    function requestDatasetId(): Observable<MaybeUndefined<string>> {
         return commitService.getIdByAccountNameAndDatasetName(TEST_ACCOUNT_NAME, TEST_DATASET_NAME);
     }
 

--- a/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.spec.ts
+++ b/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.spec.ts
@@ -4,7 +4,7 @@ import { Apollo, ApolloModule } from "apollo-angular";
 import { ApolloTestingModule } from "apollo-angular/testing";
 import { DatasetApi } from "src/app/api/dataset.api";
 import { Observable, Subscription, of } from "rxjs";
-import { mockDatasetMainDataResponse } from "src/app/search/mock.data";
+import { mockDatasetMainDataId, mockDatasetMainDataResponse } from "src/app/search/mock.data";
 import { DatasetByAccountAndDatasetNameQuery } from "src/app/api/kamu.graphql.interface";
 import { NavigationService } from "src/app/services/navigation.service";
 import {
@@ -29,7 +29,7 @@ describe("DatasetCommitService", () => {
 
     const TEST_ACCOUNT_NAME = "accountName";
     const TEST_DATASET_NAME = "datasetName";
-    const TEST_DATASET_ID: string = mockDatasetMainDataResponse.datasets.byOwnerAndName?.id as string;
+    const TEST_DATASET_ID: string = mockDatasetMainDataId;
     const TEST_EVENT_CONTENT = "event content";
 
     beforeEach(() => {
@@ -55,7 +55,7 @@ describe("DatasetCommitService", () => {
         expect(commitService).toBeTruthy();
     });
 
-    function requestDatasetId(): Observable<string> {
+    function requestDatasetId(): Observable<string | undefined> {
         return commitService.getIdByAccountNameAndDatasetName(TEST_ACCOUNT_NAME, TEST_DATASET_NAME);
     }
 

--- a/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.ts
+++ b/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.ts
@@ -7,7 +7,7 @@ import {
     DatasetByAccountAndDatasetNameQuery,
     UpdateReadmeMutation,
 } from "src/app/api/kamu.graphql.interface";
-import { MaybeNullOrUndefined } from "src/app/common/app.types";
+import { MaybeNullOrUndefined, MaybeUndefined } from "src/app/common/app.types";
 import { DatasetNotFoundError } from "src/app/common/errors";
 import { DatasetViewTypeEnum } from "src/app/dataset-view/dataset-view.interface";
 import { DatasetService } from "src/app/dataset-view/dataset.service";
@@ -58,7 +58,7 @@ export class DatasetCommitService {
 
     public getIdByAccountNameAndDatasetName(accountName: string, datasetName: string): Observable<string> {
         const key = `${accountName}/${datasetName}`;
-        const cachedId: string | undefined = this.datasetIdsByAccountDatasetName.get(key);
+        const cachedId: MaybeUndefined<string> = this.datasetIdsByAccountDatasetName.get(key);
         if (cachedId) {
             return of(cachedId);
         } else {

--- a/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.ts
+++ b/src/app/dataset-view/additional-components/overview-component/services/dataset-commit.service.ts
@@ -7,6 +7,8 @@ import {
     DatasetByAccountAndDatasetNameQuery,
     UpdateReadmeMutation,
 } from "src/app/api/kamu.graphql.interface";
+import { MaybeNullOrUndefined } from "src/app/common/app.types";
+import { DatasetNotFoundError } from "src/app/common/errors";
 import { DatasetViewTypeEnum } from "src/app/dataset-view/dataset-view.interface";
 import { DatasetService } from "src/app/dataset-view/dataset.service";
 import { NavigationService } from "src/app/services/navigation.service";
@@ -41,7 +43,7 @@ export class DatasetCommitService {
                     event,
                 }),
             ),
-            map((data: CommitEventToDatasetMutation | undefined | null) => {
+            map((data: MaybeNullOrUndefined<CommitEventToDatasetMutation>) => {
                 if (
                     data?.datasets.byId?.metadata.chain.commitEvent.__typename === "CommitResultAppendError" ||
                     data?.datasets.byId?.metadata.chain.commitEvent.__typename === "MetadataManifestMalformed"
@@ -55,16 +57,20 @@ export class DatasetCommitService {
     }
 
     public getIdByAccountNameAndDatasetName(accountName: string, datasetName: string): Observable<string> {
-        const key = `${accountName}${datasetName}`;
+        const key = `${accountName}/${datasetName}`;
         const cachedId: string | undefined = this.datasetIdsByAccountDatasetName.get(key);
         if (cachedId) {
             return of(cachedId);
         } else {
             return this.datasetApi.getDatasetInfoByAccountAndDatasetName(accountName, datasetName).pipe(
                 map((data: DatasetByAccountAndDatasetNameQuery) => {
-                    const id = data.datasets.byOwnerAndName?.id as string;
-                    this.datasetIdsByAccountDatasetName.set(key, id);
-                    return id;
+                    const id = data.datasets.byOwnerAndName?.id;
+                    if (id) {
+                        this.datasetIdsByAccountDatasetName.set(key, id);
+                        return id;
+                    } else {
+                        throw new DatasetNotFoundError(key);
+                    }
                 }),
             );
         }
@@ -73,7 +79,7 @@ export class DatasetCommitService {
     public updateReadme(accountName: string, datasetName: string, content: string): Observable<void> {
         return this.getIdByAccountNameAndDatasetName(accountName, datasetName).pipe(
             switchMap((id: string) => this.datasetApi.updateReadme(id, content)),
-            map((data: UpdateReadmeMutation | null | undefined) => {
+            map((data: MaybeNullOrUndefined<UpdateReadmeMutation>) => {
                 if (data?.datasets.byId?.metadata.updateReadme.__typename === "CommitResultSuccess") {
                     this.updatePage(accountName, datasetName);
                 }

--- a/src/app/dataset-view/additional-components/settings-component/services/dataset-settings.service.ts
+++ b/src/app/dataset-view/additional-components/settings-component/services/dataset-settings.service.ts
@@ -8,6 +8,7 @@ import { DatasetViewTypeEnum } from "src/app/dataset-view/dataset-view.interface
 import { promiseWithCatch } from "src/app/common/app.helpers";
 import { ModalService } from "src/app/components/modal/modal.service";
 import { DatasetService } from "src/app/dataset-view/dataset.service";
+import { MaybeNullOrUndefined } from "src/app/common/app.types";
 
 @Injectable({
     providedIn: "root",
@@ -32,7 +33,7 @@ export class DatasetSettingsService {
 
     public deleteDataset(datasetId: string): Observable<void> {
         return this.datasetApi.deleteDataset(datasetId).pipe(
-            map((data: DeleteDatasetMutation | undefined | null) => {
+            map((data: MaybeNullOrUndefined<DeleteDatasetMutation>) => {
                 if (data?.datasets.byId?.delete.__typename === "DeleteResultSuccess") {
                     this.navigationService.navigateToSearch();
                 } else {
@@ -52,7 +53,7 @@ export class DatasetSettingsService {
 
     public renameDataset(accountName: string, datasetId: string, newName: string): Observable<void> {
         return this.datasetApi.renameDataset(datasetId, newName).pipe(
-            map((data: RenameDatasetMutation | undefined | null) => {
+            map((data: MaybeNullOrUndefined<RenameDatasetMutation>) => {
                 if (data?.datasets.byId?.rename.__typename === "RenameResultSuccess") {
                     this.datasetService
                         .requestDatasetMainData({

--- a/src/app/dataset-view/additional-components/settings-component/settings.component.ts
+++ b/src/app/dataset-view/additional-components/settings-component/settings.component.ts
@@ -46,30 +46,34 @@ export class SettingsTabComponent extends BaseComponent implements OnInit {
     }
 
     public renameDataset(): void {
-        const datasetId = this.datasetBasics?.id as string;
-        const accountName = this.getDatasetInfoFromUrl().accountName;
-        this.trackSubscription(
-            this.datasetSettingsService
-                .renameDataset(accountName, datasetId, this.datasetName?.value as string)
-                .subscribe(),
-        );
+        if (this.datasetBasics) {
+            const datasetId = this.datasetBasics.id;
+            const accountName = this.getDatasetInfoFromUrl().accountName;
+            this.trackSubscription(
+                this.datasetSettingsService
+                    .renameDataset(accountName, datasetId, this.datasetName?.value as string)
+                    .subscribe(),
+            );
+        }
     }
 
     public deleteDataset(): void {
-        promiseWithCatch(
-            this.modalService.error({
-                title: "Delete",
-                message: "Do you want to delete a dataset?",
-                yesButtonText: "Ok",
-                noButtonText: "Cancel",
-                handler: (ok) => {
-                    if (ok) {
-                        const datasetId = this.datasetBasics?.id as string;
-                        this.trackSubscription(this.datasetSettingsService.deleteDataset(datasetId).subscribe());
-                    }
-                },
-            }),
-        );
+        if (this.datasetBasics) {
+            const datasetId = this.datasetBasics.id;
+            promiseWithCatch(
+                this.modalService.error({
+                    title: "Delete",
+                    message: "Do you want to delete a dataset?",
+                    yesButtonText: "Ok",
+                    noButtonText: "Cancel",
+                    handler: (ok) => {
+                        if (ok) {
+                            this.trackSubscription(this.datasetSettingsService.deleteDataset(datasetId).subscribe());
+                        }
+                    },
+                }),
+            );
+        }
     }
 
     public changeName(): void {

--- a/src/app/dataset-view/dataset.component.spec.ts
+++ b/src/app/dataset-view/dataset.component.spec.ts
@@ -167,7 +167,7 @@ describe("DatasetComponent", () => {
         component.onSelectDataset();
         expect(navigateToDatasetViewSpy).toHaveBeenCalledWith(
             jasmine.objectContaining({
-                datasetName: mockDatasetBasicsFragment.name as string,
+                datasetName: mockDatasetBasicsFragment.name,
             }),
         );
     });
@@ -181,7 +181,7 @@ describe("DatasetComponent", () => {
     it("should check click on metadata node ", () => {
         const selectDatasetSpy = spyOn(component, "onSelectDataset");
         component.onClickMetadataNode(mockDatasetBasicsFragment);
-        expect(selectDatasetSpy).toHaveBeenCalledWith(mockDatasetBasicsFragment.name as string);
+        expect(selectDatasetSpy).toHaveBeenCalledWith(mockDatasetBasicsFragment.name);
     });
 
     it("should check navigate to overview tab", () => {

--- a/src/app/dataset-view/dataset.component.ts
+++ b/src/app/dataset-view/dataset.component.ts
@@ -89,14 +89,14 @@ export class DatasetComponent extends BaseProcessingComponent implements OnInit,
         if (this.datasetBasics) {
             this.navigationService.navigateToDatasetView({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: this.datasetBasics.name as string,
+                datasetName: this.datasetBasics.name,
                 tab: this.datasetViewType,
                 page: currentPage,
             });
             this.initDatasetViewByType(
                 {
                     accountName: this.datasetBasics.owner.name,
-                    datasetName: this.datasetBasics.name as string,
+                    datasetName: this.datasetBasics.name,
                 },
                 currentPage,
             );
@@ -148,7 +148,7 @@ export class DatasetComponent extends BaseProcessingComponent implements OnInit,
     }
 
     public onClickMetadataNode(dataset: DatasetBasicsFragment): void {
-        this.onSelectDataset(dataset.name as string);
+        this.onSelectDataset(dataset.name);
     }
 
     public get isDatasetViewTypeOverview(): boolean {
@@ -218,7 +218,7 @@ export class DatasetComponent extends BaseProcessingComponent implements OnInit,
         if (this.datasetBasics) {
             this.navigationService.navigateToDatasetView({
                 accountName: this.datasetBasics.owner.name,
-                datasetName: datasetName ? datasetName : (this.datasetBasics.name as string),
+                datasetName: datasetName ? datasetName : this.datasetBasics.name,
                 tab: DatasetViewTypeEnum.Lineage,
             });
         }

--- a/src/app/dataset-view/dataset.component.ts
+++ b/src/app/dataset-view/dataset.component.ts
@@ -18,6 +18,7 @@ import { DatasetInfo } from "../interface/navigation.interface";
 import { promiseWithCatch } from "../common/app.helpers";
 import AppValues from "../common/app.values";
 import { BaseProcessingComponent } from "../common/base.processing.component";
+import { MaybeNull } from "../common/app.types";
 
 @Component({
     selector: "app-dataset",
@@ -71,7 +72,7 @@ export class DatasetComponent extends BaseProcessingComponent implements OnInit,
     public changeLineageGraphView(): void {
         if (this.datasetViewType === DatasetViewTypeEnum.Lineage) {
             setTimeout(() => {
-                const searchResultContainer: HTMLElement | null =
+                const searchResultContainer: MaybeNull<HTMLElement> =
                     document.getElementById("searchResultContainerContent");
                 if (searchResultContainer) {
                     const styleElement: CSSStyleDeclaration = getComputedStyle(searchResultContainer);
@@ -195,12 +196,14 @@ export class DatasetComponent extends BaseProcessingComponent implements OnInit,
     }
 
     private getCurrentPageFromUrl(): number {
-        const page: string | null = this.activatedRoute.snapshot.queryParamMap.get(ProjectLinks.URL_QUERY_PARAM_PAGE);
+        const page: MaybeNull<string> = this.activatedRoute.snapshot.queryParamMap.get(
+            ProjectLinks.URL_QUERY_PARAM_PAGE,
+        );
         return page ? Number(page) : 1;
     }
 
     private getDatasetViewTypeFromUrl(): DatasetViewTypeEnum {
-        const tabValue: string | null = this.activatedRoute.snapshot.queryParamMap.get(
+        const tabValue: MaybeNull<string> = this.activatedRoute.snapshot.queryParamMap.get(
             ProjectLinks.URL_QUERY_PARAM_TAB,
         );
         if (tabValue) {

--- a/src/app/interface/modal.interface.ts
+++ b/src/app/interface/modal.interface.ts
@@ -1,3 +1,4 @@
+import { MaybeNull } from "../common/app.types";
 import { ModalDialogComponent } from "../components/modal/modal-dialog.component";
 import { ModalImageComponent } from "../components/modal/modal-image.component";
 import { ModalSpinnerComponent } from "../components/modal/modal-spinner.component";
@@ -47,4 +48,4 @@ export interface ModalMappingsComponent {
 
 export type ModalComponentType = "dialog" | "image" | "spinner";
 
-export type NgStyleValue = Record<string, string> | null;
+export type NgStyleValue = MaybeNull<Record<string, string>>;

--- a/src/app/search/mock.data.ts
+++ b/src/app/search/mock.data.ts
@@ -155,12 +155,14 @@ export const mockDatasetResponseNotFound: GetDatasetMainDataQuery = {
     },
 };
 
+export const mockDatasetMainDataId = "did:odf:z4k88e8rxU6m5wCnK9idM5sGAxAGfvUgNgQbckwJ4ro78tXMLSu";
+
 export const mockDatasetMainDataResponse: GetDatasetMainDataQuery = {
     datasets: {
         __typename: "Datasets",
         byOwnerAndName: {
             __typename: "Dataset",
-            id: "did:odf:z4k88e8rxU6m5wCnK9idM5sGAxAGfvUgNgQbckwJ4ro78tXMLSu",
+            id: mockDatasetMainDataId,
             kind: DatasetKind.Root,
             name: "alberta.case-details",
             owner: {


### PR DESCRIPTION
Enabled configuration option for GraphQL code generator - it emits 'string' instead of 'any' by default when seeing scalars.
Cleanup of related typing fallout all over the project.