### PR TITLE
Separate sample and query data limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Changed sample query limit on overview tab
+
 ## [0.12.1] - 2023-10-13
 ### Added
 - Add UI support for ODF protocol changes of v0.32.0

--- a/src/app/api/dataset.api.spec.ts
+++ b/src/app/api/dataset.api.spec.ts
@@ -103,6 +103,7 @@ describe("DatasetApi", () => {
         const op = controller.expectOne(GetDatasetMainDataDocument);
         expect(op.operation.variables.accountName).toEqual(TEST_LOGIN);
         expect(op.operation.variables.datasetName).toEqual(TEST_DATASET_NAME);
+        expect(op.operation.variables.limit).toEqual(AppValues.SAMPLE_DATA_LIMIT);
 
         op.flush({
             data: mockDatasetMainDataResponse,

--- a/src/app/api/dataset.api.ts
+++ b/src/app/api/dataset.api.ts
@@ -72,7 +72,7 @@ export class DatasetApi {
                 {
                     accountName: params.accountName,
                     datasetName: params.datasetName,
-                    limit: params.numRecords ?? AppValues.SQL_QUERY_LIMIT,
+                    limit: params.numRecords ?? AppValues.SAMPLE_DATA_LIMIT,
                 },
                 {
                     fetchPolicy: "network-only",

--- a/src/app/common/app.values.ts
+++ b/src/app/common/app.values.ts
@@ -14,6 +14,7 @@ export default class AppValues {
     public static readonly DISPLAY_DATE_FORMAT = "DD MMM YYYY";
     public static readonly DISPLAY_TOOLTIP_DATE_FORMAT = "MMM D, YYYY, HH:mm A";
     public static readonly UNIMPLEMENTED_MESSAGE = "Feature coming soon";
+    public static readonly SAMPLE_DATA_LIMIT = 10;
     public static readonly SQL_QUERY_LIMIT = 50;
     public static readonly SHORT_DELAY_MS = 200;
     public static readonly LONG_DELAY_MS = 2000;


### PR DESCRIPTION
Overview tab displays too much data and it takes few pages of scrolling to get to readme.