### PR TITLE
Selected GraphQL errors mean authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Changed sample query limit on overview tab
+- Improved UI reaction on situation when GraphQL server refuses to accept access token
 
 ## [0.12.1] - 2023-10-13
 ### Added

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { AuthenticationError } from "./common/errors";
 import { throwError } from "rxjs";
 import { AccountTabs } from "./auth/account/account.constants";
 import { NavigationService } from "./services/navigation.service";
-import { ChangeDetectionStrategy, Component, HostListener, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, OnInit } from "@angular/core";
 import AppValues from "./common/app.values";
 import { filter, map } from "rxjs/operators";
 import { NavigationEnd, Router, RouterEvent } from "@angular/router";
@@ -58,6 +58,7 @@ export class AppComponent extends BaseComponent implements OnInit {
         private modalService: ModalService,
         private navigationService: NavigationService,
         private appConfigService: AppConfigService,
+        private cdr: ChangeDetectorRef,
     ) {
         super();
     }
@@ -78,6 +79,7 @@ export class AppComponent extends BaseComponent implements OnInit {
 
             this.loggedUserService.loggedInUserChanges.subscribe((user: MaybeNull<AccountFragment>) => {
                 this.loggedAccount = user ? _.cloneDeep(user) : AppComponent.ANONYMOUS_ACCOUNT_INFO;
+                this.cdr.detectChanges();
             }),
         );
     }


### PR DESCRIPTION
Improved error processing logic.
Displaying Toast messages for auth errors.
Immediately refreshing header UI when user token is dropped