### PR TITLE
Kamu UI 405 reset  flatten metadata option is missing for derivative datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added reset flatten option for derivative datasets
 ### Changed
 - Replaced dataset names, account names, history blocks, settings vertical tabs to links
 

--- a/src/app/dataset-view/additional-components/dataset-settings-component/tabs/general/dataset-settings-general-tab.component.html
+++ b/src/app/dataset-view/additional-components/dataset-settings-component/tabs/general/dataset-settings-general-tab.component.html
@@ -57,7 +57,7 @@
             </p>
             <form class="row" [formGroup]="resetDatasetForm">
                 <div class="d-flex flex-row">
-                    <div class="d-flex align-items-center pt-1 hint" *ngIf="isRoot">
+                    <div class="d-flex align-items-center pt-1 hint">
                         <mat-radio-group class="d-flex flex-column row-gap-1" formControlName="mode" color="primary">
                             <mat-radio-button [value]="DatasetResetMode.RESET_TO_SEED">
                                 <div class="d-flex align-items-center">


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/405

Result:
![image](https://github.com/user-attachments/assets/404f2ee2-67e4-4460-bb3c-7a3b00189168)

![image](https://github.com/user-attachments/assets/1cd26a68-1a91-48bf-bd04-b26ec1d9981f)

