### PR TITLE
Allow anon access to query explainer

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -48,7 +48,6 @@ export const routes: Routes = [
         component: AdminDashboardComponent,
     },
     {
-        canActivate: [AdminGuard],
         path: ProjectLinks.URL_QUERY_EXPLAINER,
         component: QueryExplainerComponent,
         loadChildren: () => import("./query-explainer/query-explainer.module").then((m) => m.QueryExplainerModule),


### PR DESCRIPTION
Addresses: #462 

Note this masks the problem for logged-in users but doesn't fix it fully, as auth is still required to dead the uploaded file content from `api-server`.