### PR TITLE
Kamu UI 501 improve error handling for the explainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `demo` mode: unimplemented features are disabled
   - `develop` mode: unimplemented features are available
 - Made a tile element clickable
+### Fixed
+- Fixed error handling for the query explainer
 
 ## [0.33.0] - 2024-12-03
 ### Added
@@ -77,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lineage graph: redirect to another dataset
 - Application search: redirect to another dataset
 - Lineage tab displayed correctly
-- Prettified histopy timeline
+- Prettified history timeline
 
 ## [0.27.0] - 2024-09-25
 ### Added

--- a/src/app/query-explainer/query-explainer.service.spec.ts
+++ b/src/app/query-explainer/query-explainer.service.spec.ts
@@ -126,7 +126,7 @@ describe("QueryExplainerService", () => {
     });
 
     it("should return error when fetch commitment data by upload token", () => {
-        const errorMessage = "Error";
+        const errorMessage = "Uploaded file not found on the server";
         const toastrServiceSpy = spyOn(toastrService, "error");
         const uploadToken = "dfdflLKDsddfdddlfdsdsjkpbfopofoFDdfdf";
 
@@ -140,7 +140,11 @@ describe("QueryExplainerService", () => {
         const req = httpTestingController.expectOne(
             `${appConfigService.apiServerHttpUrl}/platform/file/upload/${uploadToken}`,
         );
-        req.flush(errorMessage, { status: 404, statusText: "Not found" });
+
+        req.flush({ message: errorMessage }, { status: 404, statusText: "Not found" });
         expect(toastrServiceSpy).toHaveBeenCalledTimes(1);
+        expect(toastrServiceSpy).toHaveBeenCalledWith("", errorMessage, {
+            disableTimeOut: "timeOut",
+        });
     });
 });

--- a/src/app/query-explainer/query-explainer.service.ts
+++ b/src/app/query-explainer/query-explainer.service.ts
@@ -60,7 +60,7 @@ export class QueryExplainerService {
         };
         return this.http.post<QueryExplainerDataJsonAosResponse>(url.href, body).pipe(
             catchError((e: HttpErrorResponse) => {
-                this.toastrService.error("", e.error as string, {
+                this.toastrService.error("", (e.error as { message: string }).message, {
                     disableTimeOut: "timeOut",
                 });
                 return EMPTY;
@@ -74,7 +74,7 @@ export class QueryExplainerService {
             catchError((e: HttpErrorResponse) => {
                 if (e.status === 400) return of(e.error as VerifyQueryResponse);
                 else {
-                    this.toastrService.error("", e.error as string, {
+                    this.toastrService.error("", (e.error as { message: string }).message, {
                         disableTimeOut: "timeOut",
                     });
                     return EMPTY;
@@ -87,7 +87,7 @@ export class QueryExplainerService {
         const url = new URL(`${this.baseUrl}/platform/file/upload/${token}`);
         return this.http.get<QueryExplainerResponse>(url.href).pipe(
             catchError((e: HttpErrorResponse) => {
-                this.toastrService.error("", e.error as string, {
+                this.toastrService.error("", (e.error as { message: string }).message, {
                     disableTimeOut: "timeOut",
                 });
                 return EMPTY;


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/501

Result:

![image](https://github.com/user-attachments/assets/57840e5d-495c-49b1-a190-6053724bed84)
