### PR TITLE
Kamu UI 569 metadata block page  for set transform event private inputs are not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Remove "Dashboard" link from application header
 - Disabled "keywords" feature for "demo" mode
+- Metadata block page for SetTransfom: private inputs are not displayed for non-admin
 
 ## [0.40.1] - 2025-02-20
 ### Changed

--- a/src/app/common/tooltips/set-transform.text.ts
+++ b/src/app/common/tooltips/set-transform.text.ts
@@ -11,4 +11,5 @@ export class SetTransformTooltipsTexts {
     public static readonly DATASET_OWNER = "Owner of the dataset.";
     public static readonly DATASET_ALIAS = "Query alias of the dataset.";
     public static readonly DATASET_REF = "A local or remote dataset reference to use in dataset resolutions.";
+    public static readonly DATASET_NOT_ACCEESSABLE = "Dataset accessability";
 }

--- a/src/app/common/tooltips/set-transform.text.ts
+++ b/src/app/common/tooltips/set-transform.text.ts
@@ -11,5 +11,5 @@ export class SetTransformTooltipsTexts {
     public static readonly DATASET_OWNER = "Owner of the dataset.";
     public static readonly DATASET_ALIAS = "Query alias of the dataset.";
     public static readonly DATASET_REF = "A local or remote dataset reference to use in dataset resolutions.";
-    public static readonly DATASET_NOT_ACCEESSABLE = "Dataset accessability";
+    public static readonly DATASET_NOT_ACCESSIBLE = "Dataset accessibility";
 }

--- a/src/app/dataset-block/metadata-block/components/event-details/components/set-transform-event/set-transform-event.source.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/set-transform-event/set-transform-event.source.ts
@@ -36,6 +36,14 @@ export const SET_TRANSFORM_SOURCE_DESCRIPTORS: EventRowDescriptorsByField = {
         dataTestId: "set-transform-datasetNotAccessible-datasetRef",
     },
 
+    "SetTransform.TransformInputDatasetNotAccessible.message": {
+        label: "Dataset:",
+        tooltip: SetTransformTooltipsTexts.DATASET_NOT_ACCEESSABLE,
+        presentationComponent: SimplePropertyComponent,
+        separateRowForValue: false,
+        dataTestId: "set-transform-datasetNotAccessible-type",
+    },
+
     "SetTransform.Dataset.kind": {
         label: "Dataset type:",
         tooltip: SetTransformTooltipsTexts.DATASET_KIND,

--- a/src/app/dataset-block/metadata-block/components/event-details/components/set-transform-event/set-transform-event.source.ts
+++ b/src/app/dataset-block/metadata-block/components/event-details/components/set-transform-event/set-transform-event.source.ts
@@ -38,7 +38,7 @@ export const SET_TRANSFORM_SOURCE_DESCRIPTORS: EventRowDescriptorsByField = {
 
     "SetTransform.TransformInputDatasetNotAccessible.message": {
         label: "Dataset:",
-        tooltip: SetTransformTooltipsTexts.DATASET_NOT_ACCEESSABLE,
+        tooltip: SetTransformTooltipsTexts.DATASET_NOT_ACCESSIBLE,
         presentationComponent: SimplePropertyComponent,
         separateRowForValue: false,
         dataTestId: "set-transform-datasetNotAccessible-type",


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/569

Result:
![image](https://github.com/user-attachments/assets/3194579e-6ef9-40fb-aadb-cf5def5659e9)
