### PR TITLE
Kamu UI 574 query explainer  page empty if query returns empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove "Dashboard" link from application header
 - Disabled "keywords" feature for "demo" mode
 - Metadata block page for SetTransfom: private inputs are not displayed for non-admin
+- Query explainer: page empty if query returns empty result
 
 ## [0.40.1] - 2025-02-20
 ### Changed

--- a/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.html
+++ b/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.html
@@ -2,11 +2,15 @@
     <div class="fw-semibold">Reproduced result:</div>
     <div class="mt-4">
         <app-dynamic-table
+            *ngIf="tableSource(dataJsonAoS).length; else emptyResult"
             [hasTableHeader]="true"
             [schemaFields]="schemaFields(dataJsonAoS)"
             [idTable]="'query-explainer-table'"
             [dataRows]="tableSource(dataJsonAoS)"
             [attr.data-test-id]="'query-explainer-table'"
         />
+        <ng-template #emptyResult>
+            <p data-test-id="emptyResult">0 records</p>
+        </ng-template>
     </div>
 </div>

--- a/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.spec.ts
+++ b/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.spec.ts
@@ -8,7 +8,8 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReproducedResultSectionComponent } from "./reproduced-result-section.component";
 import { DynamicTableModule } from "src/app/common/components/dynamic-table/dynamic-table.module";
-import { mockQueryExplainerOutput } from "../../query-explainer.mocks";
+import { mockQueryExplainerEmptyOutput, mockQueryExplainerOutput } from "../../query-explainer.mocks";
+import { findElementByDataTestId } from "src/app/common/helpers/base-test.helpers.spec";
 
 describe("ReproducedResultSectionComponent", () => {
     let component: ReproducedResultSectionComponent;
@@ -22,10 +23,17 @@ describe("ReproducedResultSectionComponent", () => {
         fixture = TestBed.createComponent(ReproducedResultSectionComponent);
         component = fixture.componentInstance;
         component.dataJsonAoS = mockQueryExplainerOutput;
-        fixture.detectChanges();
     });
 
     it("should create", () => {
+        fixture.detectChanges();
         expect(component).toBeTruthy();
+    });
+
+    it("should check empty data result", () => {
+        component.dataJsonAoS = mockQueryExplainerEmptyOutput;
+        fixture.detectChanges();
+        const emptyElement = findElementByDataTestId(fixture, "emptyResult");
+        expect(emptyElement?.textContent?.trim()).toEqual("0 records");
     });
 });

--- a/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.ts
+++ b/src/app/query-explainer/components/reproduced-result-section/reproduced-result-section.component.ts
@@ -25,6 +25,6 @@ export class ReproducedResultSectionComponent {
     }
 
     public schemaFields(output: QueryExplainerOutputType): DataSchemaField[] {
-        return extractSchemaFieldsFromData(this.tableSource(output)[0]);
+        return extractSchemaFieldsFromData(this.tableSource(output)[0] ?? []);
     }
 }

--- a/src/app/query-explainer/query-explainer.mocks.ts
+++ b/src/app/query-explainer/query-explainer.mocks.ts
@@ -78,6 +78,35 @@ export const mockQueryExplainerOutput: QueryExplainerOutputType = {
     },
 };
 
+export const mockQueryExplainerEmptyOutput: QueryExplainerOutputType = {
+    data: [],
+
+    dataFormat: "JsonAoA",
+    schemaFormat: "ArrowJson",
+    schema: {
+        fields: [
+            {
+                name: "offset",
+            },
+            {
+                name: "op",
+            },
+            {
+                name: "system_time",
+            },
+            {
+                name: "event_time",
+            },
+            {
+                name: "A",
+            },
+            {
+                name: "B",
+            },
+        ],
+    },
+};
+
 export const mockVerifyQueryResponseSuccess: VerifyQueryResponse = { ok: true };
 export const mockVerifyQueryResponseError: VerifyQueryResponse = {
     ok: false,


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/574

Result:

![localhost_4200_v_query-explainer_commitmentUploadToken=eyJ1cGxvYWRfaWQiOiJlNWI0MWFiYTlmZjI0ZjRlODAyODY3ZTQ5ZmMyODU1NCIsImZpbGVfbmFtZSI6InF1ZXJ5LWV4cGxhaW5lci5qc29uIiwib3duZXJfYWNjb3VudF9pZCI6ImZlZDAxNmI2MWVkMmFiMWI](https://github.com/user-attachments/assets/0199cde6-4c6e-4cc3-b5e8-022d3b8db484)
