### PR TITLE
Account settings: the "Email" option is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Account settings: the "Email" option is now available
+
 ## [0.42.0] - 2025-03-20
 ### Added
 - Login page: added ability to switch buttons with tab

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -79,7 +79,6 @@ export const routes: Routes = [
     },
     {
         path: `${ProjectLinks.URL_SETTINGS}`,
-        component: AccountSettingsComponent,
         children: [
             {
                 path: "",


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/592