### PR TITLE
Kamu UI 651 history tab  make equal indents for nodes and align the horizontal line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unrealesed]
+### Fixed
+History tab: make equal indents for nodes and align the horizontal line for timeline item
+
 ## [0.47.0] - 2025-05-14
 ### Added
 - Ethereum logs source: show blockchain logo and chain name in Lineage graph

--- a/src/app/common/components/timeline-component/timeline.component.html
+++ b/src/app/common/components/timeline-component/timeline.component.html
@@ -6,7 +6,7 @@
         <div class="timeline-block__body">
             <ol class="mt-2 list-unstyled box box--condensed ml-n6 ml-sm-0 position-relative">
                 <li
-                    class="box__row box__row--focus-gray mt-0 d-flex"
+                    class="box__row box__row--focus-gray d-flex"
                     data-url="/kamu-data/kamu-web-ui/commits/75e711dfb8e35335b622f0c56ff59fc3fc7cea7d/commits_list_item"
                 >
                     <div class="flex-auto min-width-0 details">

--- a/src/app/common/components/timeline-component/timeline.component.scss
+++ b/src/app/common/components/timeline-component/timeline.component.scss
@@ -18,7 +18,7 @@
                 width: 2px;
                 top: 36px;
                 left: 15px;
-                height: 65px;
+                height: 60px;
                 content: "";
                 background-color: $app-color-border-muted;
             }
@@ -30,7 +30,7 @@
             width: 2px;
             top: 36px;
             left: 15px;
-            height: 93px;
+            height: 89px;
             content: "";
             background-color: $app-color-border-muted;
         }
@@ -40,10 +40,10 @@
             display: block;
             height: 1px;
             width: 21px;
-            top: 27px;
+            top: 27.5px;
             left: 28px;
             content: "";
-            background-color: #b7b7b8;
+            background-color: $app-color-border-muted;
         }
     }
 }
@@ -80,6 +80,6 @@ a {
 
 .commit-icon {
     position: absolute;
-    top: 18px;
+    top: 19px;
     left: 8px;
 }


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/651

Result:

![image](https://github.com/user-attachments/assets/72c9fd33-44bc-4cfe-93c0-138a4b7ac821)
