### PR TITLE
Kamu 697 Flows tab: extend text message for root and derivative datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] 
 ### Added
 - Flows tab: added `update now` link when flows list is empty
+### Fixed
+- Compaction tab: fixed bug with `Run compaction` button
 
 
 ## [0.51.0] - 2025-07-11
@@ -18,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjustments for API changes in flow system
 - SetTransform event: improved search
 - Migrated to standalone components
-
-## [Unreleased] 
-### Fixed
-- Compaction tab: fixed bug with `Run compaction` button
 
 
 ## [0.50.0] - 2025-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+### Added
+- Flows tab: added `update now` link when flows list is empty
+
+
 ## [0.51.0] - 2025-07-11
 ### Added
 - Added compression of file sizes when the server responds to a request

--- a/src/app/dataset-view/additional-components/flows-component/flows.component.html
+++ b/src/app/dataset-view/additional-components/flows-component/flows.component.html
@@ -93,7 +93,7 @@
     </ng-container>
     <ng-template #noRuns>
         <p class="ps-2 pt-2" data-test-id="empty-flow-runs-block">
-            <ng-container *ngIf="!isSetTransformEmpty && !isSetPollingSourceEmpty">
+            <ng-container *ngIf="!isSetTransformEmpty && !isSetPollingSourceEmpty && !hasPushSources">
                 No flow runs.
                 <span *ngIf="canRunFlows">
                     You can
@@ -108,6 +108,7 @@
                         ]"
                         >update configuration settings</a
                     >
+                    or <a class="text-decoration-none" (click)="updateNow()">update now</a>
                 </span>
             </ng-container>
             <ng-container *ngIf="isSetPollingSourceEmpty">
@@ -136,6 +137,7 @@
                     >add transformation
                 </a>
             </ng-container>
+            <ng-container *ngIf="hasPushSources"> No flow runs. </ng-container>
         </p>
     </ng-template>
     <ng-template #loading>

--- a/src/app/dataset-view/additional-components/flows-component/flows.component.html
+++ b/src/app/dataset-view/additional-components/flows-component/flows.component.html
@@ -108,7 +108,8 @@
                         ]"
                         >update configuration settings</a
                     >
-                    or <a class="text-decoration-none" (click)="updateNow()">update now</a>
+                    or
+                    <a class="text-decoration-none" (click)="updateNow()" data-test-id="update-now-link">update now</a>
                 </span>
             </ng-container>
             <ng-container *ngIf="isSetPollingSourceEmpty">

--- a/src/app/dataset-view/additional-components/flows-component/flows.component.spec.ts
+++ b/src/app/dataset-view/additional-components/flows-component/flows.component.spec.ts
@@ -26,7 +26,7 @@ import { mockFlowsTableData } from "src/app/api/mock/dataset-flow.mock";
 import { SettingsTabsEnum } from "../dataset-settings-component/dataset-settings.model";
 import { mockDatasetBasicsDerivedFragment } from "src/app/search/mock.data";
 
-fdescribe("FlowsComponent", () => {
+describe("FlowsComponent", () => {
     let component: FlowsComponent;
     let fixture: ComponentFixture<FlowsComponent>;
     let datasetFlowsService: DatasetFlowsService;
@@ -197,6 +197,33 @@ fdescribe("FlowsComponent", () => {
     }));
 
     it("should check 'update now' link for root dataset with PollingSource", fakeAsync(() => {
+        fixture.detectChanges();
+        mockFlowsTableData.connectionDataForWidget.nodes = [];
+        mockFlowsTableData.connectionDataForTable.nodes = [];
+        spyOn(datasetFlowsService, "allFlowsPaused").and.returnValue(of(false));
+        spyOn(datasetFlowsService, "datasetFlowsList").and.returnValue(of(mockFlowsTableData).pipe(delay(10)));
+        spyOn(datasetFlowsService, "flowsInitiators").and.returnValue(of([]));
+        tick(10);
+        fixture.detectChanges();
+        const updateNowClickSpy = spyOn(component, "updateNow");
+        const updateNowLink = findElementByDataTestId(fixture, "update-now-link");
+        expect(updateNowLink).toBeDefined();
+        updateNowLink?.click();
+        expect(updateNowClickSpy).toHaveBeenCalledTimes(1);
+        discardPeriodicTasks();
+    }));
+
+    it("should check 'update now' link for derivative dataset with SetTransform", fakeAsync(() => {
+        const copyMockOverviewUpdate = structuredClone(mockOverviewUpdate);
+        copyMockOverviewUpdate.overview.metadata.currentPollingSource = null;
+        copyMockOverviewUpdate.overview.metadata.currentTransform = {
+            __typename: "SetTransform",
+        };
+        component.flowsData = {
+            datasetBasics: mockDatasetBasicsDerivedFragment,
+            datasetPermissions: mockFullPowerDatasetPermissionsFragment,
+            overviewUpdate: copyMockOverviewUpdate,
+        };
         fixture.detectChanges();
         mockFlowsTableData.connectionDataForWidget.nodes = [];
         mockFlowsTableData.connectionDataForTable.nodes = [];

--- a/src/app/dataset-view/additional-components/flows-component/flows.component.spec.ts
+++ b/src/app/dataset-view/additional-components/flows-component/flows.component.spec.ts
@@ -26,7 +26,7 @@ import { mockFlowsTableData } from "src/app/api/mock/dataset-flow.mock";
 import { SettingsTabsEnum } from "../dataset-settings-component/dataset-settings.model";
 import { mockDatasetBasicsDerivedFragment } from "src/app/search/mock.data";
 
-describe("FlowsComponent", () => {
+fdescribe("FlowsComponent", () => {
     let component: FlowsComponent;
     let fixture: ComponentFixture<FlowsComponent>;
     let datasetFlowsService: DatasetFlowsService;
@@ -193,6 +193,23 @@ describe("FlowsComponent", () => {
         fixture.detectChanges();
         const progressBarAfter = findElementByDataTestId(fixture, "init-progress-bar");
         expect(progressBarAfter).toBeUndefined();
+        discardPeriodicTasks();
+    }));
+
+    it("should check 'update now' link for root dataset with PollingSource", fakeAsync(() => {
+        fixture.detectChanges();
+        mockFlowsTableData.connectionDataForWidget.nodes = [];
+        mockFlowsTableData.connectionDataForTable.nodes = [];
+        spyOn(datasetFlowsService, "allFlowsPaused").and.returnValue(of(false));
+        spyOn(datasetFlowsService, "datasetFlowsList").and.returnValue(of(mockFlowsTableData).pipe(delay(10)));
+        spyOn(datasetFlowsService, "flowsInitiators").and.returnValue(of([]));
+        tick(10);
+        fixture.detectChanges();
+        const updateNowClickSpy = spyOn(component, "updateNow");
+        const updateNowLink = findElementByDataTestId(fixture, "update-now-link");
+        expect(updateNowLink).toBeDefined();
+        updateNowLink?.click();
+        expect(updateNowClickSpy).toHaveBeenCalledTimes(1);
         discardPeriodicTasks();
     }));
 });

--- a/src/app/dataset-view/additional-components/flows-component/flows.component.ts
+++ b/src/app/dataset-view/additional-components/flows-component/flows.component.ts
@@ -100,15 +100,21 @@ export class FlowsComponent extends FlowsTableProcessingBaseComponent implements
     public get isSetPollingSourceEmpty(): boolean {
         return (
             !this.flowsData.overviewUpdate.overview.metadata.currentPollingSource &&
-            this.flowsData.datasetBasics.kind === DatasetKind.Root
+            this.flowsData.datasetBasics.kind === DatasetKind.Root &&
+            !this.hasPushSources
         );
     }
 
     public get isSetTransformEmpty(): boolean {
         return (
             !this.flowsData.overviewUpdate.overview.metadata.currentTransform &&
-            this.flowsData.datasetBasics.kind === DatasetKind.Derivative
+            this.flowsData.datasetBasics.kind === DatasetKind.Derivative &&
+            !this.hasPushSources
         );
+    }
+
+    public get hasPushSources(): boolean {
+        return Boolean(this.flowsData.overviewUpdate.overview.metadata.currentPushSources.length);
     }
 
     public get canRunFlows(): boolean {


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/697

Result for PollingSource and SetTransform:

<img width="1691" height="846" alt="image" src="https://github.com/user-attachments/assets/1e9973c7-dd11-4bdc-8b0e-7d38abfaa8be" />


Result for PushSource:

<img width="1739" height="827" alt="image" src="https://github.com/user-attachments/assets/f9d2ae4d-9512-4213-b539-be01e272c3ce" />
