### PR TITLE
Kamu UI 728 data tab  redesign of the verify query result button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoiding full re-rendering of flow listing tables on polling source updates
 - "History" tab redesign  
 - Metadata block page: сhanged display of ID for input section
+- Data tab: added "Generate proof" toggle
 
 ## [0.53.0] - 2025-07-23
 ### Changed

--- a/angular.json
+++ b/angular.json
@@ -62,6 +62,7 @@
               "node_modules/prismjs/prism.js",
               "node_modules/prismjs/components/prism-sql.min.js",
               "node_modules/prismjs/components/prism-css.min.js",
+              "node_modules/prismjs/components/prism-json.min.js",
               "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js",
               "node_modules/prismjs/plugins/line-highlight/prism-line-highlight.js",
               "node_modules/prismjs/plugins/command-line/prism-command-line.js",

--- a/src/app/dataset-view/additional-components/data-component/data.component.html
+++ b/src/app/dataset-view/additional-components/data-component/data.component.html
@@ -1,6 +1,6 @@
 <div class="query-container">
     <app-search-and-schemas-section [disableSearch]="true"></app-search-and-schemas-section>
-    <div class="search-result-container__content">
+    <div class="search-result-container__content mb-50">
         <app-query-and-result-sections
             [sqlLoading]="sqlLoading"
             [sqlError]="sqlErrorMarker$ | async"

--- a/src/app/dataset-view/additional-components/data-component/data.component.scss
+++ b/src/app/dataset-view/additional-components/data-component/data.component.scss
@@ -1,0 +1,3 @@
+.mb-50 {
+    margin-bottom: 50px;
+}

--- a/src/app/dataset-view/additional-components/data-component/data.component.ts
+++ b/src/app/dataset-view/additional-components/data-component/data.component.ts
@@ -33,6 +33,7 @@ import { EditorModule } from "src/app/editor/editor.module";
 @Component({
     selector: "app-data",
     templateUrl: "./data.component.html",
+    styleUrls: ["./data.component.scss"],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
     imports: [

--- a/src/app/query-explainer/query-explainer.service.ts
+++ b/src/app/query-explainer/query-explainer.service.ts
@@ -7,7 +7,7 @@
 
 import { HttpClient, HttpErrorResponse, HttpHeaders } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
-import { catchError, EMPTY, map, Observable, of, tap } from "rxjs";
+import { catchError, EMPTY, map, Observable, of, ReplaySubject, Subject, tap } from "rxjs";
 import { AppConfigService } from "src/app/app-config.service";
 import {
     QueryExplainerDataJsonAosResponse,
@@ -30,6 +30,18 @@ export class QueryExplainerService {
     private loggedUserService = inject(LoggedUserService);
     private localStorageService = inject(LocalStorageService);
     private baseUrl: string;
+
+    private proofResponse$: Subject<QueryExplainerProofResponse> = new ReplaySubject<QueryExplainerProofResponse>(
+        1 /*bufferSize*/,
+    );
+
+    public emitProofResponseChanged(data: QueryExplainerProofResponse): void {
+        this.proofResponse$.next(data);
+    }
+
+    public get proofResponseChanges(): Observable<QueryExplainerProofResponse> {
+        return this.proofResponse$.asObservable();
+    }
 
     public constructor() {
         this.baseUrl = `${this.appConfigService.apiServerHttpUrl}`;

--- a/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.html
+++ b/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.html
@@ -1,5 +1,5 @@
 <div class="sql-query-editor-header d-flex flex-row justify-content-between">
-    <div class="box-title align-items-center pb-3 m-0 d-flex flex-row gap-3">
+    <div class="box-title pb-3 m-0 d-flex flex-row align-items-center gap-3">
         <span class="d-block">Engine:</span>
         <app-engine-select
             *ngIf="knownEngines$ | async as knownEngines"
@@ -7,6 +7,16 @@
             [engine]="selectedEngine"
             [disabledOptionsMode]="true"
         ></app-engine-select>
+
+        <mat-slide-toggle
+            *ngIf="isAuthenticated"
+            [(ngModel)]="enabledProof"
+            color="primary"
+            class="mat-elevation-z0 ml-90"
+            data-test-id="generate-proof-enabled"
+        >
+            <span class="ps-2"> Generate proof</span>
+        </mat-slide-toggle>
     </div>
     <div class="btn-group-parent">
         <div class="d-flex">
@@ -15,15 +25,17 @@
                 [disabled]="!sqlRequestCode"
                 data-test-id="shareSqlQueryButton"
                 (click)="shareQuery()"
+                [title]="'Share query'"
                 class="share-query-button border border-1 rounded justify-content-center align-items-center me-4"
             >
-                <span class="mr-1 button-text"> Share query</span><mat-icon>share</mat-icon>
+                <mat-icon>share</mat-icon>
             </button>
             <button
                 appFeatureFlag="dataset.panel.data.editRun"
                 data-test-id="runSqlQueryButton"
                 [disabled]="!sqlRequestCode || sqlLoading"
                 name="run sql button"
+                [title]="'Run SQL query'"
                 (click)="runSQLRequest({ query: sqlRequestCode }, true)"
                 class="sql-run-button border border-1 rounded-left-2 border-right-0 btn-group-item btn justify-content-center align-items-center"
             >
@@ -53,17 +65,6 @@
                     <mat-divider></mat-divider>
                 </div>
                 <ng-container *ngIf="isAdmin">
-                    <div appFeatureFlag="dataset.panel.data.editRun.verify" class="select-menu-list">
-                        <button type="button" (click)="verifyQueryResult()" class="select-menu-item flex-items-start">
-                            <div>
-                                <div class="f5 text-bold">Verify query result</div>
-                                <div class="text-small color-fg-muted text-normal pb-1 lh-130">
-                                    You can verify the query result and make sure that you can trust it
-                                </div>
-                            </div>
-                        </button>
-                        <mat-divider></mat-divider>
-                    </div>
                     <div appFeatureFlag="dataset.panel.data.editRun.curl" class="select-menu-list">
                         <button type="button" (click)="copyCurlCommand()" class="select-menu-item flex-items-start">
                             <div>
@@ -80,7 +81,7 @@
     </div>
 </div>
 
-<div class="position-relative mt-4">
+<div class="position-relative mt-2">
     <ng-container *ngIf="!this.editorLoaded || sqlLoading">
         <mat-progress-bar data-test-id="editor-progress-bar" class="position-absolute" mode="indeterminate" />
     </ng-container>
@@ -126,6 +127,24 @@
         <ng-template #noRecords>
             <h3>0 records</h3>
         </ng-template>
+    </ng-container>
+
+    <ng-container *ngIf="enabledProof && proofResponse && !sqlError">
+        <div class="d-flex justify-content-between align-items-center mt-4">
+            <h2 class="box-title align-items-center pb-3 m-0">Query Proof:</h2>
+        </div>
+        <div class="mt-2">
+            <markdown clipboard class="variable-binding" [data]="jsonWrapper(proofResponse)" />
+        </div>
+        <div class="d-flex justify-content-end mt-4 pb-30">
+            <button
+                data-test-id="shareSqlQueryButton"
+                (click)="verifyQueryResult()"
+                class="verify-query-button border border-1 rounded justify-content-center align-items-center"
+            >
+                <span class="mr-1 button-text"> Verify</span><mat-icon>beenhere</mat-icon>
+            </button>
+        </div>
     </ng-container>
 </ng-container>
 

--- a/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.scss
+++ b/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.scss
@@ -18,7 +18,8 @@
     border-bottom-left-radius: 5px;
 }
 
-.share-query-button {
+.share-query-button,
+.verify-query-button {
     display: flex;
     color: #1a7f37;
     padding: 5px 10px;
@@ -41,4 +42,12 @@
 
 .no-pointer {
     cursor: not-allowed;
+}
+
+.pb-30 {
+    padding-bottom: 30px;
+}
+
+.ml-90 {
+    margin-left: 90px;
 }

--- a/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.spec.ts
+++ b/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.spec.ts
@@ -27,6 +27,7 @@ import { FileUploadService } from "src/app/services/file-upload.service";
 import { DatasetRequestBySql } from "src/app/interface/dataset.interface";
 import { EngineService } from "src/app/dataset-view/additional-components/metadata-component/components/set-transform/components/engine-section/engine.service";
 import { mockEngines } from "src/app/dataset-view/additional-components/metadata-component/components/set-transform/mock.data";
+import { MarkdownModule } from "ngx-markdown";
 
 describe("QueryAndResultSectionsComponent", () => {
     let component: QueryAndResultSectionsComponent;
@@ -39,7 +40,13 @@ describe("QueryAndResultSectionsComponent", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, EditorModule, SharedTestModule, QueryAndResultSectionsComponent],
+            imports: [
+                HttpClientTestingModule,
+                EditorModule,
+                SharedTestModule,
+                QueryAndResultSectionsComponent,
+                MarkdownModule.forRoot(),
+            ],
             providers: [Apollo, provideToastr()],
         });
         fixture = TestBed.createComponent(QueryAndResultSectionsComponent);
@@ -144,15 +151,23 @@ describe("QueryAndResultSectionsComponent", () => {
         expect(clipboardCopySpy).toHaveBeenCalledTimes(1);
     });
 
-    it("should check click on `Verify query result` button", () => {
-        const processQuerySpy = spyOn(queryExplainerService, "processQueryWithProof").and.returnValue(
-            of(mockQueryExplainerResponse),
-        );
+    it("should check click on `Verify` button", () => {
         const uploadFilePrepareSpy = spyOn(fileUploadService, "uploadFilePrepare").and.returnValue(
             of(mockUploadPrepareResponse),
         );
         component.verifyQueryResult();
-        expect(processQuerySpy).toHaveBeenCalledTimes(1);
         expect(uploadFilePrepareSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should run the query when the Generate proof' switch is enabled", () => {
+        component.enabledProof = true;
+        const processQuerySpy = spyOn(queryExplainerService, "processQueryWithProof").and.returnValue(
+            of(mockQueryExplainerResponse),
+        );
+
+        component.runSQLRequest({ query: "select * from 'mock-dataset'" });
+
+        expect(processQuerySpy).toHaveBeenCalledTimes(1);
+        expect(component.proofResponse).toEqual(mockQueryExplainerResponse);
     });
 });

--- a/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.ts
+++ b/src/app/query/shared/query-and-result-sections/query-and-result-sections.component.ts
@@ -105,7 +105,7 @@ export class QueryAndResultSectionsComponent extends BaseComponent implements On
     public selectedEngine = AppValues.DEFAULT_ENGINE_NAME.toLowerCase();
     public knownEngines$: Observable<EngineDesc[]>;
     public enabledProof: boolean = false;
-    public proofResponse: QueryExplainerProofResponse;
+    public proofResponse: MaybeNull<QueryExplainerProofResponse>;
 
     public ngOnInit(): void {
         this.knownEngines$ = this.engineService.engines().pipe(map((result) => result.data.knownEngines));


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/728

Result:

<img width="1900" height="2043" alt="localhost_4200_kamu_account tokens portfolio_data_sqlQuery=select%0A%20%20_%0Afrom%20%27kamu%2Faccount tokens portfolio%27%20limit%202" src="https://github.com/user-attachments/assets/e8dfa6ca-fc09-4a3f-b562-c8f4c3bdd5f3" />


<img width="1900" height="1423" alt="localhost_4200_kamu_account tokens portfolio_data_sqlQuery=select%0A%20%20_%0Afrom%20%27kamu%2Faccount tokens portfolio%27%20lidmit%202" src="https://github.com/user-attachments/assets/e4146a07-029a-47c9-bcc0-fec34b919095" />
