### PR TITLE
Dataset "Settings" tab: the active tab in the menu does not switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Data tab: fixed view for "Saved queries" block
+- Settings tab: active tab is highlighted correctly
 ### Changed
 - Avoiding full re-rendering of flow listing tables on polling source updates
 - "History" tab redesign  

--- a/src/app/dataset-view/additional-components/dataset-settings-component/dataset-settings-routing.ts
+++ b/src/app/dataset-view/additional-components/dataset-settings-component/dataset-settings-routing.ts
@@ -36,6 +36,7 @@ export const DATASET_SETTINGS_ROUTES: Routes = [
     {
         path: "",
         component: DatasetSettingsComponent,
+        runGuardsAndResolvers: "always",
         resolve: {
             [RoutingResolvers.DATASET_VIEW_SETTINGS_KEY]: datasetSettingsTabResolverFn,
             [RoutingResolvers.DATASET_VIEW_SETTINGS_ACTIVE_SECTION_KEY]: datasetSettingsActiveSectionResolverFn,


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/731