### PR TITLE
Kamu UI 737 cannot upload new data after reset to metadata only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require initial choice of radio buttons in transform options form
 - Time delta form is not disabled initially in ingest schedule
 - Improved setting form labels - auto disable when control is disabled
+- Can upload new data after "Reset to Metadata only"
 
 ## [0.55.0] - 2025-08-20
 ### Added

--- a/src/app/dataset-view/additional-components/overview-component/overview.component.spec.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview.component.spec.ts
@@ -251,6 +251,7 @@ describe("OverviewComponent", () => {
         it("should check show Add data button without currentPollingSource", () => {
             currentOverview().metadata.currentPollingSource = null;
             spyOnProperty(loggedUserService, "isAuthenticated", "get").and.returnValue(true);
+            component.datasetOverviewTabData.datasetPermissions.permissions.metadata.canCommit = true;
             fixture.detectChanges();
 
             expect(component.showAddDataButton).toEqual(true);
@@ -306,15 +307,6 @@ describe("OverviewComponent", () => {
 
             const refreshButton = findElementByDataTestId(fixture, "refresh-now-button") as HTMLButtonElement;
             expect(refreshButton.disabled).toBeTrue();
-        });
-
-        it("should check show Add data button without currentTransform", () => {
-            component.datasetOverviewTabData.datasetBasics = mockDatasetBasicsDerivedFragment;
-            currentOverview().metadata.currentTransform = null;
-            spyOnProperty(loggedUserService, "isAuthenticated", "get").and.returnValue(true);
-            fixture.detectChanges();
-
-            expect(component.showAddDataButton).toEqual(true);
         });
 
         it("should check don't show Add data button with currentTransform", () => {

--- a/src/app/dataset-view/additional-components/overview-component/overview.component.ts
+++ b/src/app/dataset-view/additional-components/overview-component/overview.component.ts
@@ -254,12 +254,11 @@ export class OverviewComponent extends BaseDatasetDataComponent implements OnIni
     }
 
     public get showAddDataButton(): boolean {
-        if (Boolean(this.datasetOverviewTabData.overviewUpdate.content.length) && this.isUserLogged) {
+        if (this.isUserLogged) {
             return (
-                (!this.datasetOverviewTabData.overviewUpdate.overview.metadata.currentPollingSource &&
-                    this.datasetOverviewTabData.datasetBasics.kind === DatasetKind.Root) ||
-                (!this.datasetOverviewTabData.overviewUpdate.overview.metadata.currentTransform &&
-                    this.datasetOverviewTabData.datasetBasics.kind === DatasetKind.Derivative)
+                !this.datasetOverviewTabData.overviewUpdate.overview.metadata.currentPollingSource &&
+                this.datasetOverviewTabData.datasetBasics.kind === DatasetKind.Root &&
+                this.datasetOverviewTabData.datasetPermissions.permissions.metadata.canCommit
             );
         } else {
             return false;


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/737

Result:

<img width="1836" height="912" alt="image" src="https://github.com/user-attachments/assets/da8f5c06-1d73-4284-a34d-9735924351e3" />
