### PR TITLE
Kamu UI 739 change font for did, hashes and signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redesign "Metadata" tab
 - Updated the algorithm for checking the hash of the head
 - Replaced local storage methods for URL redirection with `redirectUrl` parameter
+- Changed font for DID, hashes and signatures
 ### Fixed
 - Require initial choice of radio buttons in transform options form
 - Time delta form is not disabled initially in ingest schedule

--- a/src/app/common/components/display-hash/display-hash.component.html
+++ b/src/app/common/components/display-hash/display-hash.component.html
@@ -2,15 +2,19 @@
     <a
         *ngIf="navigationTargetDataset"
         [title]="value"
-        [class]="class"
+        [class]="'font-monospace ' + class"
         data-test-id="navigableValue"
         [routerLink]="['/', navigationTargetDataset.accountName, navigationTargetDataset.datasetName, URL_BLOCK, value]"
         >{{ value | slice: -8 }}</a
     >
 
-    <span *ngIf="!navigationTargetDataset" class="mr-1" [title]="value" data-test-id="notNavigableValue">{{
-        value | slice: -8
-    }}</span>
+    <span
+        *ngIf="!navigationTargetDataset"
+        class="mr-1 font-monospace"
+        [title]="value"
+        data-test-id="notNavigableValue"
+        >{{ value | slice: -8 }}</span
+    >
 
     <button
         *ngIf="showCopyButton"

--- a/src/app/dataset-block/metadata-block/components/block-navigation/block-navigation.component.html
+++ b/src/app/dataset-block/metadata-block/components/block-navigation/block-navigation.component.html
@@ -59,7 +59,7 @@
                         >
                         <div
                             [innerHTML]="highlightHash(block.blockHash, searchHash)"
-                            class="ml-29 mt-2 fs-10 text-muted"
+                            class="ml-29 mt-2 fs-12 text-muted font-monospace"
                         ></div>
                     </div>
 

--- a/src/app/dataset-view/additional-components/metadata-component/tabs/metadata-transformation-tab/metadata-transformation-tab.component.html
+++ b/src/app/dataset-view/additional-components/metadata-component/tabs/metadata-transformation-tab/metadata-transformation-tab.component.html
@@ -19,7 +19,7 @@
             <span class="position-absolute text-muted group-box-label text-uppercase">Input {{ i + 1 }}</span>
             <div class="mx-4">
                 <app-block-row-data [tooltip]="'Unique dataset identifier.'" [label]="'Id:'">
-                    <span>{{ input.inputDataset.dataset.id }}</span>
+                    <span class="font-monospace">{{ input.inputDataset.dataset.id }}</span>
                 </app-block-row-data>
             </div>
             <div class="mx-4">

--- a/src/app/dataset-view/additional-components/overview-component/components/overview-history-summary-header/overview-history-summary-header.component.html
+++ b/src/app/dataset-view/additional-components/overview-component/components/overview-history-summary-header/overview-history-summary-header.component.html
@@ -59,7 +59,7 @@
                             accountName: metadataBlockFragment.author.accountName,
                             datasetName: this.datasetName,
                         }"
-                        [class]="'f6 link--secondary text-mono ml-2 d-none d-lg-inline'"
+                        [class]="'f4 link--secondary text-mono ml-2 d-none d-lg-inline'"
                     />
                     <a class="link--secondary ml-3">
                         <app-display-time

--- a/src/app/query-explainer/components/commitment-data-section/commitment-data-section.component.html
+++ b/src/app/query-explainer/components/commitment-data-section/commitment-data-section.component.html
@@ -6,6 +6,7 @@
             <div class="mt-2 text-break">
                 <span
                     data-test-id="input-hash"
+                    class="font-monospace"
                     [class.error-color]="isInputHashError(commitmentData.sqlQueryVerify?.error)"
                     >{{ commitmentData.sqlQueryExplainerResponse.commitment.inputHash }}
                 </span>
@@ -20,6 +21,7 @@
             <div class="mt-2 text-break">
                 <span
                     data-test-id="output-hash"
+                    class="font-monospace"
                     [class.error-color]="isOutputMismatchError(commitmentData.sqlQueryVerify?.error)"
                 >
                     {{ commitmentData.sqlQueryExplainerResponse.commitment.outputHash }}</span
@@ -35,6 +37,7 @@
             <div class="mt-2 text-break">
                 <span
                     data-test-id="sub-queries-hash"
+                    class="font-monospace"
                     [class.error-color]="isSubQueriesHashError(commitmentData.sqlQueryVerify?.error)"
                     >{{ commitmentData.sqlQueryExplainerResponse.commitment.subQueriesHash }}
                 </span>
@@ -63,13 +66,13 @@
         </div>
         <div class="m-4">
             <div class="fw-semibold">ODF Node DID:</div>
-            <div class="mt-2 text-break">
+            <div class="mt-2 text-break font-monospace">
                 {{ commitmentData.sqlQueryExplainerResponse.proof.verificationMethod }}
             </div>
         </div>
         <div class="m-4">
             <div class="fw-semibold">Signature:</div>
-            <div class="mt-2 text-break">
+            <div class="mt-2 text-break font-monospace">
                 <span [class.error-color]="isBadSignatureError(commitmentData.sqlQueryVerify?.error)">
                     {{ commitmentData.sqlQueryExplainerResponse.proof.proofValue }}
                 </span>

--- a/src/app/query-explainer/components/input-data-section/input-data-section.component.html
+++ b/src/app/query-explainer/components/input-data-section/input-data-section.component.html
@@ -54,6 +54,7 @@
                                     "
                                     routerLink="/{{ datasetInfo.accountName }}/{{ datasetInfo.datasetName }}"
                                     target="_blank"
+                                    class="font-monospace"
                                     attr.data-test-id="input-dataset-id-{{ i }}"
                                 >
                                     {{ dataset.id }}


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/739

Result:

<img width="1306" height="384" alt="image" src="https://github.com/user-attachments/assets/4985b378-1750-427e-9b6a-e10d881ef1ab" />

<img width="1863" height="849" alt="image" src="https://github.com/user-attachments/assets/fddb3a68-a345-4668-b5e2-f2088b45859a" />
