### PR TITLE
Kamu UI 847 lineage tab  error displaying a dataset without a source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Lineage tab: error displaying a dataset without a source
+
 ## [0.66.0] - 2026-05-16
 ### Added
 - Preview for the dataset as a collection

--- a/src/app/common/components/lineage-graph/lineage-graph.component.html
+++ b/src/app/common/components/lineage-graph/lineage-graph.component.html
@@ -231,7 +231,7 @@
         </ng-template>
 
         <ng-template #linkTemplate let-link>
-            <svg:g class="edge">
+            <svg:g class="edge" [style.opacity]="link.data?.isHidden ? 0 : 1">
                 <path class="line" stroke-width="2" [attr.d]="link.line" marker-end="url(#arrow)"></path>
             </svg:g>
         </ng-template>

--- a/src/app/dataset-view/additional-components/lineage-component/services/lineage-graph-builder.service.ts
+++ b/src/app/dataset-view/additional-components/lineage-component/services/lineage-graph-builder.service.ts
@@ -50,6 +50,20 @@ export class LineageGraphBuilderService {
                         nodes: [...sourceSubgraph.nodes, ...datasetSubgraph.nodes],
                         links: [...sourceSubgraph.links, ...datasetSubgraph.links],
                     };
+
+                    // Workaround for ngx-graph: the 'dagre' layout crashes if the graph contains nodes but 0 links.
+                    // Adding a hidden self-loop edge prevents the "Cannot read properties of undefined (reading 'nodes')" error.
+                    const { nodes, links } = graph;
+                    if (nodes.length === 1 && links.length === 0) {
+                        const singleNodeId = graph.nodes[0].id;
+                        graph.links.push({
+                            id: `hidden-loop-link-${singleNodeId}`,
+                            source: singleNodeId,
+                            target: singleNodeId,
+                            data: { isHidden: true },
+                        });
+                    }
+
                     return {
                         graph,
                         originDataset: lineageUpdate.origin,


### PR DESCRIPTION
Closes: https://github.com/kamu-data/kamu-web-ui/issues/847



Result:
<img width="1834" height="962" alt="image" src="https://github.com/user-attachments/assets/001e4efb-f245-48e3-858d-309d3e5c963c" />


